### PR TITLE
Handbook-inspired Refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 _site
+.sass-cache

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ etc. These containers all can contain out layout or typographical block elements
 Note that we are not using the `main` element yet. While it looks great, until its more widely
 adopted we're going to stick with the semantic equivalent, `<div class="main" rel="main">`.
 
-### .mold
+### .container
 Sometimes we need to identify which elements should be constrained to the maximum width we believe
-the site is best viewed at. Sometimes this is called `.wrapper` or `.container`, but we're using
-`.mold` as a classname that we will only use for this purpose.
+the site is best viewed at. Some people this is called `.wrapper` or `.frame`, but we're using
+`.container` as a classname that we will only use for this purpose.
 
 ### Primary, Secondary, and Tertiary
 We use the classes `primary`, `secondary`, and `tertiary` to identify layout elements that might occur

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,3 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600);
 /* = Table of Contents =
 
  * Colors
@@ -18,143 +17,148 @@
  * Internet Explorer
  * Print Styles
  */
+
 /* = Colors = */
+
 /* = Web Fonts = */
+@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600);
+
 /* = Base = */
 a, abbr, address, article, aside, audio, b, blockquote, body, canvas, cite,
 code, dd, div, dl, dt, em, fieldset, footer, form, h1, h2, h3, h4, h5, h6,
 header, html, i, iframe, img, label, li, nav, object, ol, p, pre, section,
 span, strong, sub, sup, table, tbody, td, tfoot, th, thead, tr, ul, video {
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  margin: 0;
-  outline: 0;
-  padding: 0;
-  vertical-align: baseline;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	margin: 0;
+	outline: 0;
+	padding: 0;
+	vertical-align: baseline;
 }
 
 article, aside, footer, header, nav, section {
-  display: block;
+	display: block;
 }
 
 audio, canvas, video {
-  display: inline-block;
+	display: inline-block;
 }
 
 img {
-  -ms-interpolation-mode: bicubic;
-  max-width: 100%;
-  vertical-align: middle;
+	-ms-interpolation-mode: bicubic;
+	max-width: 100%;
+	vertical-align: middle;
 }
 
 html {
-  background: #fcfcfc;
-  color: #555555;
-  font-family: Arial, Helvetica, sans-serif;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
+	background: #fcfcfc;
+	color: #555555;
+	font-family: Arial, Helvetica, sans-serif;
+	-ms-text-size-adjust: 100%;
+	-webkit-text-size-adjust: 100%;
 }
 
 body {
-  font-size: 16px;
-  line-height: 1.5;
-  min-width: 310px;
+	font-size: 16px;
+	line-height: 1.5;
+	min-width: 310px;
 }
 
 ::-moz-selection {
-  background: #fff6b5;
-  text-shadow: none;
+	background: #fff6b5;
+	text-shadow: none;
 }
 
 ::selection {
-  background: #fff6b5;
-  text-shadow: none;
+	background: #fff6b5;
+	text-shadow: none;
 }
 
 /* = Mixins = */
+
 /* = Grouping = */
 .group:before, .group:after,
 .container:before,
 .container:after {
-  content: '';
-  display: table;
+	content: '';
+	display: table;
 }
 .group:after,
 .container:after {
-  clear: both;
+	clear: both;
 }
 
 .columns {
-  display: table;
-  table-layout: fixed;
-  width: 100%;
+	display: table;
+	table-layout: fixed;
+	width: 100%;
 }
 .columns > * {
-  display: table-cell;
-  width: 100%;
+	display: table-cell;
+	width: 100%;
 }
 
 /* = Layout = */
 header.primary,
 .torso,
 footer.primary {
-  position: relative;
-  margin-bottom: 2.5em;
+	position: relative;
+	margin-bottom: 2.5em;
 }
 
 header.primary {
-  background: #1a1a1a;
+	background: #1a1a1a;
 }
 header.primary .branding {
-  padding: 1.5em 16px;
+	padding: 1.5em 16px;
 }
 header.primary .branding h1 {
-  margin: 0;
+	margin: 0;
 }
 header.primary .branding h1 a {
-  color: #fcfcfc;
+	color: #fcfcfc;
 }
 
 .torso .main,
 .torso aside.primary {
-  padding-left: 16px;
-  padding-right: 16px;
+	padding-left: 16px;
+	padding-right: 16px;
 }
 .torso .main article .meta,
 .torso aside.primary article .meta {
-  color: #888888;
-  font-size: .875em;
-  margin-top: -.5em;
-  margin-bottom: 1em;
+	color: #888888;
+	font-size: .875em;
+	margin-top: -.5em;
+	margin-bottom: 1em;
 }
 .torso .main article,
 .torso .main section {
-  margin-bottom: 3em;
+	margin-bottom: 3em;
 }
 .torso .main aside {
-  background: #eee;
-  border-radius: 5px;
-  color: #888;
-  float: right;
-  font-size: .875em;
-  line-height: 1.43em;
-  margin-bottom: 1.333em;
-  margin-left: 1.333em;
-  padding: 1.333em;
-  text-shadow: 0px 1px 0px #fff;
-  width: 33.33%;
+	background: #eee;
+	border-radius: 5px;
+	color: #888;
+	float: right;
+	font-size: .875em;
+	line-height: 1.43em;
+	margin-bottom: 1.333em;
+	margin-left: 1.333em;
+	padding: 1.333em;
+	text-shadow: 0px 1px 0px #fff;
+	width: 33.33%;
 }
 .torso aside.primary article,
 .torso aside.primary section {
-  margin-bottom: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 footer.primary {
-  color: #888888;
-  font-size: 0.875em;
-  padding-left: 16px;
-  padding-right: 16px;
+	color: #888888;
+	font-size: 0.875em;
+	padding-left: 16px;
+	padding-right: 16px;
 }
 
 /* = Typography = */
@@ -164,8 +168,8 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: normal;
+	font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-weight: normal;
 }
 h1:first-child,
 h2:first-child,
@@ -173,188 +177,188 @@ h3:first-child,
 h4:first-child,
 h5:first-child,
 h6:first-child {
-  margin-top: 0;
+	margin-top: 0;
 }
 
 h1 {
-  color: #f2006d;
-  font-size: 3em;
-  line-height: 1.2;
-  margin-top: 1.67em;
-  margin-bottom: .5em;
+	color: #f2006d;
+	font-size: 3em;
+	line-height: 1.2;
+	margin-top: 1.67em;
+	margin-bottom: .5em;
 }
 
 h2 {
-  font-size: 2.5em;
-  line-height: 1.2;
-  margin-top: 1.2em;
-  margin-bottom: .4em;
+	font-size: 2.5em;
+	line-height: 1.2;
+	margin-top: 1.2em;
+	margin-bottom: .4em;
 }
 
 h1 + h2 {
-  margin-top: -.2em;
+	margin-top: -.2em;
 }
 
 h3 {
-  font-size: 1.5em;
-  line-height: 1.3;
-  margin-top: 1.8em;
-  margin-bottom: .4em;
+	font-size: 1.5em;
+	line-height: 1.3;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
 
 h2 + h3 {
-  margin-top: -.4em;
-  margin-bottom: .2em;
+	margin-top: -.4em;
+	margin-bottom: .2em;
 }
 
 h4 {
-  font-size: 1.25em;
-  line-height: 1.4;
-  margin-top: 1.8em;
-  margin-bottom: .4em;
+	font-size: 1.25em;
+	line-height: 1.4;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
 
 h3 + h4 {
-  margin-top: -.3em;
+	margin-top: -.3em;
 }
 
 h5 {
-  font-size: 1em;
-  margin-top: 1.8em;
-  margin-bottom: .4em;
+	font-size: 1em;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
 
 h4 + h5 {
-  margin-top: -.3em;
+	margin-top: -.3em;
 }
 
 h6 {
-  font-size: .9em;
-  margin-top: 1.8em;
-  margin-bottom: .4em;
+	font-size: .9em;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
 
 h5 + h6 {
-  margin-top: -.2em;
+	margin-top: -.2em;
 }
 
 abbr[title] {
-  border-bottom: 1px dotted;
+	border-bottom: 1px dotted;
 }
 
 b,
 strong {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 i,
 em {
-  font-style: italic;
+	font-style: italic;
 }
 
 blockquote,
 pre {
-  color: #888888;
-  margin-bottom: 1.5em;
+	color: #888888;
+	margin-bottom: 1.5em;
 }
 blockquote:before, blockquote:after,
 pre:before,
 pre:after {
-  content: '';
-  display: table;
+	content: '';
+	display: table;
 }
 blockquote:after,
 pre:after {
-  clear: both;
+	clear: both;
 }
 
 blockquote {
-  font-style: italic;
-  border-left: 1px solid #cccccc;
-  margin-left: 2em;
-  margin-right: 1em;
-  padding-left: 1em;
-  padding-right: 1em;
+	font-style: italic;
+	border-left: 1px solid #cccccc;
+	margin-left: 2em;
+	margin-right: 1em;
+	padding-left: 1em;
+	padding-right: 1em;
 }
 
 .main .intro {
-  border-bottom: 1px solid #cccccc;
-  margin-bottom: 2.5em;
-  padding-bottom: 1.5em;
+	border-bottom: 1px solid #cccccc;
+	margin-bottom: 2.5em;
+	padding-bottom: 1.5em;
 }
 .main .intro p {
-  color: #888;
-  font-size: 1.25em;
-  line-height: 1.6;
-  margin-bottom: .8em;
+	color: #888;
+	font-size: 1.25em;
+	line-height: 1.6;
+	margin-bottom: .8em;
 }
 .main .highlight {
-  background: #e9e9e9;
-  border-radius: 5px;
-  color: #888;
-  font-size: 1.5em;
-  line-height: 1.34;
-  margin-bottom: 1em;
-  padding: .67em;
-  text-shadow: 0px 1px 0px #fff;
+	background: #e9e9e9;
+	border-radius: 5px;
+	color: #888;
+	font-size: 1.5em;
+	line-height: 1.34;
+	margin-bottom: 1em;
+	padding: .67em;
+	text-shadow: 0px 1px 0px #fff;
 }
 .main .highlight p {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 pre,
 code {
-  font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace;
-  font-size: .9em;
+	font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace;
+	font-size: .9em;
 }
 
 pre {
-  white-space: pre;
-  white-space: pre-wrap;
-  word-wrap: break-word;
+	white-space: pre;
+	white-space: pre-wrap;
+	word-wrap: break-word;
 }
 
 p {
-  margin-bottom: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 address {
-  margin-bottom: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 hr {
-  border: 0;
-  border-top: 1px solid #999;
-  display: block;
-  height: 0;
-  margin: 2em auto 3em;
-  width: 75%;
+	border: 0;
+	border-top: 1px solid #999;
+	display: block;
+	height: 0;
+	margin: 2em auto 3em;
+	width: 75%;
 }
 
 a {
-  color: #0096d2;
-  text-decoration: none;
+	color: #0096d2;
+	text-decoration: none;
 }
 a:visited {
-  color: #0096d2;
+	color: #0096d2;
 }
 a:hover, a:active {
-  color: #888888;
-  outline: 0;
+	color: #888888;
+	outline: 0;
 }
 a:focus {
-  outline: thin dotted;
+	outline: thin dotted;
 }
 
 ol,
 ul,
 dl {
-  margin-bottom: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 ol,
 ul {
-  padding-left: 2em;
+	padding-left: 2em;
 }
 ol li,
 ol dt,
@@ -362,127 +366,127 @@ ol dd,
 ul li,
 ul dt,
 ul dd {
-  margin-bottom: .5em;
+	margin-bottom: .5em;
 }
 
 ul {
-  list-style: disc;
+	list-style: disc;
 }
 
 dt {
-  font-weight: bold;
-  padding-left: .5em;
+	font-weight: bold;
+	padding-left: .5em;
 }
 
 dd {
-  padding-left: 2em;
+	padding-left: 2em;
 }
 
 sup,
 sub {
-  font-size: 80%;
+	font-size: 80%;
 }
 
 sup {
-  vertical-align: top;
+	vertical-align: top;
 }
 
 sub {
-  vertical-align: bottom;
+	vertical-align: bottom;
 }
 
 /* = Navigation = */
 nav ul {
-  list-style: none;
-  margin-bottom: 0;
-  padding-left: 0;
+	list-style: none;
+	margin-bottom: 0;
+	padding-left: 0;
 }
 nav ul:before, nav ul:after {
-  content: '';
-  display: table;
+	content: '';
+	display: table;
 }
 nav ul:after {
-  clear: both;
+	clear: both;
 }
 nav ul li {
-  display: block;
-  margin-bottom: 0;
+	display: block;
+	margin-bottom: 0;
 }
 nav ul li a {
-  white-space: nowrap;
-  display: block;
+	display: block;
 }
 
 header nav ul {
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 header nav ul li {
-  padding-left: 1em;
+	padding-left: 1em;
 }
 header nav ul li a,
 header nav ul li a:visited {
-  color: #888888;
+	color: #888888;
 }
 header nav ul li a:hover {
-  color: #fcfcfc;
+	color: #fcfcfc;
 }
 header nav ul li ul li {
-  float: left;
+	float: left;
 }
 header nav ul li ul li a {
-  font-size: .75em;
-  line-height: 1.34;
-  padding: .33em 1em .33em;
+	font-size: .75em;
+	line-height: 1.34;
+	padding: .33em 1em .33em;
 }
 header nav.primary ul li.active {
-  background: #2a2a2a;
+	background: #2a2a2a;
 }
 header nav.primary > ul > li > a {
-  color: #cccccc;
-  font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+	color: #cccccc;
+	font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+	white-space: nowrap;
 }
 header nav.primary > ul > li > a:hover {
-  color: #fcfcfc;
+	color: #fcfcfc;
 }
 header nav.primary > ul > li.active > a {
-  color: #0096d2;
+	color: #0096d2;
 }
 header nav.utility {
-  display: none;
+	display: none;
 }
 header nav.utility ul li a {
-  font-size: .75em;
-  line-height: 2;
-  padding-left: .667em;
-  padding-right: .667em;
+	font-size: .75em;
+	line-height: 2;
+	padding-left: .667em;
+	padding-right: .667em;
 }
 header nav.secondary {
-  display: none;
+	display: none;
 }
 
 aside nav > ul li a {
-  padding-top: .5em;
-  padding-bottom: .5em;
+	padding-top: .5em;
+	padding-bottom: .5em;
 }
 aside nav > ul li a:hover {
-  color: #555555;
+	color: #555555;
 }
 aside nav > ul li ul li a {
-  color: #888888;
-  font-size: .75em;
-  line-height: 1.34;
-  padding-top: .333em;
-  padding-bottom: .333em;
+	color: #888888;
+	font-size: .75em;
+	line-height: 1.34;
+	padding-top: .333em;
+	padding-bottom: .333em;
 }
 aside nav > ul li ul li:last-child a {
-  padding-top: .333em;
-  padding-bottom: 1em;
+	padding-top: .333em;
+	padding-bottom: 1em;
 }
 aside nav > ul > li {
-  border-top: 1px solid #ddd;
+	border-top: 1px solid #ddd;
 }
 aside nav > ul > li:first-child {
-  border-top: none;
+	border-top: none;
 }
 
 /* = Forms = */
@@ -490,7 +494,7 @@ button,
 input,
 select,
 textarea {
-  font-size: 100%;
+	font-size: 100%;
 }
 
 .button,
@@ -503,87 +507,87 @@ textarea {
 .submit,
 .text,
 .textarea {
-  margin-bottom: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 label {
-  color: #333;
-  cursor: pointer;
-  display: block;
-  font-weight: bold;
-  line-height: 2;
+	color: #333;
+	cursor: pointer;
+	display: block;
+	font-weight: bold;
+	line-height: 2;
 }
 
 span.required {
-  color: #ac181b;
+	color: #ac181b;
 }
 
 fieldset .help {
-  color: #888;
-  display: block;
-  font-size: .75em;
-  line-height: 1.34;
-  margin: 0;
-  padding: 0;
+	color: #888;
+	display: block;
+	font-size: .75em;
+	line-height: 1.34;
+	margin: 0;
+	padding: 0;
 }
 
 input[type="text"],
 input[type="password"],
 textarea {
-  border-radius: 2px;
-  border: 0;
-  box-shadow: 0 1px 4px 0 #848484 inset;
-  color: #333;
-  display: block;
-  font-size: 1em;
-  line-height: 2;
-  margin: 0;
-  padding-left: 1%;
-  padding-right: 1%;
-  width: 98%;
+	border-radius: 2px;
+	border: 0;
+	box-shadow: 0 1px 4px 0 #848484 inset;
+	color: #333;
+	display: block;
+	font-size: 1em;
+	line-height: 2;
+	margin: 0;
+	padding-left: 1%;
+	padding-right: 1%;
+	width: 98%;
 }
 
 select {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .multiple select {
-  padding-left: 5px;
-  padding-right: 10px;
+	padding-left: 5px;
+	padding-right: 10px;
 }
 
 textarea {
-  height: 12em;
-  overflow: auto;
-  resize: vertical;
+	height: 12em;
+	overflow: auto;
+	resize: vertical;
 }
 
 .radio,
 .checkbox {
-  font-weight: normal;
+	font-weight: normal;
 }
 
 input[type="checkbox"],
 input[type="radio"] {
-  -ms-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 input[type="file"] {
-  color: #333;
-  display: block;
-  font-size: 1em;
-  width: 100%;
+	color: #333;
+	display: block;
+	font-size: 1em;
+	width: 100%;
 }
 
 button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
-  -webkit-appearance: button;
-  cursor: pointer;
+	-webkit-appearance: button;
+	cursor: pointer;
 }
 
 button,
@@ -591,408 +595,410 @@ input[type="button"],
 input[type="reset"],
 input[type="submit"],
 a.button {
-  background: #0394cd;
-  border-radius: 3px;
-  border: none;
-  color: #fff;
-  display: inline-block;
-  font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 600;
-  line-height: 1;
-  margin-bottom: .5em;
-  margin-right: .5em;
-  padding: .5em .5em;
-  text-align: center;
+	background: #0394cd;
+	border-radius: 3px;
+	border: none;
+	color: #fff;
+	display: inline-block;
+	font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-weight: 600;
+	line-height: 1;
+	margin-bottom: .5em;
+	margin-right: .5em;
+	padding: .5em .5em;
+	text-align: center;
 }
 button:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover,
 a.button:hover {
-  background: #13abe8;
-  cursor: pointer;
+	background: #13abe8;
+	cursor: pointer;
 }
 button:focus,
 input[type="button"]:focus,
 input[type="reset"]:focus,
 input[type="submit"]:focus,
 a.button:focus {
-  background: #0084b8;
+	background: #0084b8;
 }
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
+	border: 0;
+	padding: 0;
 }
 
 /* = Messaging = */
 .messaging {
-  border-radius: 5px;
-  margin-bottom: 1.5em;
-  padding: 1em 3.25em;
-  position: relative;
+	border-radius: 5px;
+	margin-bottom: 1.5em;
+	padding: 1em 3.25em;
+	position: relative;
 }
 .messaging a {
-  text-decoration: underline;
+	text-decoration: underline;
 }
 .messaging:before {
-  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA5FJREFUeNrsWG9klVEYv/fuirFc3ZSxLJsRq2vLZYlL2fpQSpG0qU8jSynNqJbbt8bWKEsfpsSITf+UEku1NEWWImaXWMVIaZQxxpj1PPmd6+k4O+e8995J3Ief+77vPe/vnPd5nvP8OeHFxcXQckl4Ocmjmfp6n3EbCE8JKwithCc+L0U8F3GDUEkoJwwSygpFfoiQEvdxQroQ5LzCXlzPEqZw3UGoyZf8FKGC8JGwjrCe0A/d9+VDzqSduB4lzOD6Nn53E7blSt4rDLcgnstrXn1JUPIUDOkS9uO2oOR9AfZKFyHmS84rTgYgjwvbWMml6wURo2vq5Gl4iS7l4trk30bXDE/U1cmXJjDQJP1wxxOW7d9EeGFaeZeFWK1uRvi7SS5J14wI12u2vPSMcITQQzjq65oRzHTVYbCYZnSXa8YVeQdmtEkD4RVC7zUP1+xVBv1Mv1UFTkIcQdeG/9scWiQ3lxZ/dtDAD9N/pdhYnHG2ajGHc+kblBicmeZ8Q24Jcuc3wgDhgCGYVWLiAYxLm0JHxLABRhDhYp5fH8OufIdJjeQ887Ar6VokQRiTITmiRbQGB8EvwsGlMg/i/kPYK0teZUu0Qt4T7hIuWsbUwmZZ8jZHLFeyA2H3jmPcaV59FDc+Cfk5Vp7EJK7ImIoacqSNWOn6E6HaVXYrtcx7qOOsuF/l8aWlijzjaUylQh/y74r8kafOQx76VjKqyB8QPniS+xify4upiKhc27UKVhdF2unwc+Y4n42KogY/bknAPVBJtcNTziBi/kXOcp3wk3BTbWGD19jkAuGyLeTeI2wUHUQQeelTn38htBBWEw7D4LPaGFMKSwdpuFhFQ4T9hJWcFgU2GbJQoywLo3mkyAy+rgwddhIZa7JYWvxj8i0jiXx5EvCUK3wz1jQe6Egk5Gjjh1GOPFaFfyHIYyCuEOcBg4Ug59hzHypR8hW9U17kXPLdgp6VcJe3CxPkRc4N2l5xP48QMZ7LGZcUThbHtGetsrnNlZwPHbq1Z+cQ3LxK6NoliBtRMuste4/veUsz+v9u7QQoAc+QJR9XDCd9j6GSYmWd2BAxsUlkvf4W4XbB2baQrJGlL2QnCvo5rbPgeL1nqVbFtPIZpDJdarRNMg1fnvaxvqwVWX/7LEcec1jxpK9r6QZlI21WdYe2SVqg61Cu5Crzb9dcrNWznjQaNGRYKW+O19D7UDGHFkx+CzAA6nHUdfvIb58AAAAASUVORK5CYII=);
-  background-position: 0 0;
-  background-repeat: no-repeat;
-  content: '';
-  display: block;
-  height: 23px;
-  left: 1em;
-  position: absolute;
-  top: 1em;
-  width: 23px;
+	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA5FJREFUeNrsWG9klVEYv/fuirFc3ZSxLJsRq2vLZYlL2fpQSpG0qU8jSynNqJbbt8bWKEsfpsSITf+UEku1NEWWImaXWMVIaZQxxpj1PPmd6+k4O+e8995J3Ief+77vPe/vnPd5nvP8OeHFxcXQckl4Ocmjmfp6n3EbCE8JKwithCc+L0U8F3GDUEkoJwwSygpFfoiQEvdxQroQ5LzCXlzPEqZw3UGoyZf8FKGC8JGwjrCe0A/d9+VDzqSduB4lzOD6Nn53E7blSt4rDLcgnstrXn1JUPIUDOkS9uO2oOR9AfZKFyHmS84rTgYgjwvbWMml6wURo2vq5Gl4iS7l4trk30bXDE/U1cmXJjDQJP1wxxOW7d9EeGFaeZeFWK1uRvi7SS5J14wI12u2vPSMcITQQzjq65oRzHTVYbCYZnSXa8YVeQdmtEkD4RVC7zUP1+xVBv1Mv1UFTkIcQdeG/9scWiQ3lxZ/dtDAD9N/pdhYnHG2ajGHc+kblBicmeZ8Q24Jcuc3wgDhgCGYVWLiAYxLm0JHxLABRhDhYp5fH8OufIdJjeQ887Ar6VokQRiTITmiRbQGB8EvwsGlMg/i/kPYK0teZUu0Qt4T7hIuWsbUwmZZ8jZHLFeyA2H3jmPcaV59FDc+Cfk5Vp7EJK7ImIoacqSNWOn6E6HaVXYrtcx7qOOsuF/l8aWlijzjaUylQh/y74r8kafOQx76VjKqyB8QPniS+xify4upiKhc27UKVhdF2unwc+Y4n42KogY/bknAPVBJtcNTziBi/kXOcp3wk3BTbWGD19jkAuGyLeTeI2wUHUQQeelTn38htBBWEw7D4LPaGFMKSwdpuFhFQ4T9hJWcFgU2GbJQoywLo3mkyAy+rgwddhIZa7JYWvxj8i0jiXx5EvCUK3wz1jQe6Egk5Gjjh1GOPFaFfyHIYyCuEOcBg4Ug59hzHypR8hW9U17kXPLdgp6VcJe3CxPkRc4N2l5xP48QMZ7LGZcUThbHtGetsrnNlZwPHbq1Z+cQ3LxK6NoliBtRMuste4/veUsz+v9u7QQoAc+QJR9XDCd9j6GSYmWd2BAxsUlkvf4W4XbB2baQrJGlL2QnCvo5rbPgeL1nqVbFtPIZpDJdarRNMg1fnvaxvqwVWX/7LEcec1jxpK9r6QZlI21WdYe2SVqg61Cu5Crzb9dcrNWznjQaNGRYKW+O19D7UDGHFkx+CzAA6nHUdfvIb58AAAAASUVORK5CYII=);
+	background-position: 0 0;
+	background-repeat: no-repeat;
+	content: '';
+	display: block;
+	height: 23px;
+	left: 1em;
+	position: absolute;
+	top: 1em;
+	width: 23px;
 }
 
 .success {
-  background: #ecfae8;
+	background: #ecfae8;
 }
 .success:before {
-  background-position: 0 -46px;
+	background-position: 0 -46px;
 }
 
 .error {
-  background: #ffd7d7;
+	background: #ffd7d7;
 }
 .error:before {
-  background-position: 0 0;
+	background-position: 0 0;
 }
 
 .info {
-  background: #bde5f8;
+	background: #bde5f8;
 }
 .info:before {
-  background-position: 0 -23px;
+	background-position: 0 -23px;
 }
 
 /* = Tables = */
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
-  margin-bottom: 1.5em;
-  width: 100%;
+	border-collapse: collapse;
+	border-spacing: 0;
+	margin-bottom: 1.5em;
+	width: 100%;
 }
 table caption {
-  font-size: .75em;
+	font-size: .75em;
 }
 table td,
 table th {
-  padding: .25em 8px;
-  text-align: left;
-  vertical-align: top;
+	padding: .25em 8px;
+	text-align: left;
+	vertical-align: top;
 }
 table th {
-  font-weight: bold;
+	font-weight: bold;
 }
 table thead th {
-  border-bottom: 1px solid #999;
+	border-bottom: 1px solid #999;
 }
 
 /* = Section Specific = */
+
 /* = Page Specific = */
+
 /* = Media Queries = */
 @media only screen and (min-width: 640px) {
-  blockquote {
-    margin-left: 3em;
-    margin-right: 3em;
-  }
+	blockquote {
+		margin-left: 3em;
+		margin-right: 3em;
+	}
 
-  header > .container {
-    position: relative;
-  }
-  header nav {
-    position: relative;
-  }
-  header nav ul {
-    margin-bottom: 0;
-  }
-  header nav ul li {
-    padding-left: 0;
-    float: left;
-  }
-  header nav ul li ul li {
-    float: none;
-  }
-  header nav ul li ul li a {
-    padding-left: 0;
-    line-height: 2;
-  }
-  header nav > ul > li {
-    position: relative;
-  }
-  header nav > ul > li > a {
-    padding: .25em 16px;
-  }
-  header nav > ul > li .dropdown {
-    box-shadow: 0 3px 5px 0px #1a1a1a;
-    display: none;
-    position: absolute;
-    left: 0;
-    background: #2a2a2a;
-    z-index: 1;
-    padding-left: 16px;
-    padding-right: 16px;
-    min-width: 192px;
-    -ms-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-  header nav > ul > li:hover .dropdown {
-    display: block;
-  }
-  header nav.primary ul li.active {
-    background: none;
-  }
-  header nav.primary ul li:hover a {
-    background: #2a2a2a;
-  }
-  header nav.secondary {
-    display: block;
-    background: #2a2a2a;
-  }
-  header nav.secondary ul li {
-    float: left;
-  }
-  header nav.secondary ul li a {
-    font-size: .75em;
-    padding: 0 12px;
-    line-height: 2.67;
-  }
-  header nav.secondary ul li:first-child a {
-    padding-left: 16px;
-  }
-  header nav.secondary ul li.active a {
-    color: #fcfcfc;
-  }
-  header nav.utility {
-    display: block;
-    position: absolute;
-    top: 1em;
-    right: 32px;
-  }
+	header > .container {
+		position: relative;
+	}
+	header nav {
+		position: relative;
+	}
+	header nav ul {
+		margin-bottom: 0;
+	}
+	header nav ul li {
+		padding-left: 0;
+		float: left;
+	}
+	header nav ul li ul li {
+		float: none;
+	}
+	header nav ul li ul li a {
+		padding-left: 0;
+		line-height: 2;
+	}
+	header nav > ul > li {
+		position: relative;
+	}
+	header nav > ul > li > a {
+		padding: .25em 16px;
+	}
+	header nav > ul > li .dropdown {
+		box-shadow: 0 3px 5px 0px #1a1a1a;
+		display: none;
+		position: absolute;
+		left: 0;
+		background: #2a2a2a;
+		z-index: 1;
+		padding-left: 16px;
+		padding-right: 16px;
+		min-width: 192px;
+		-ms-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+	}
+	header nav > ul > li:hover .dropdown {
+		display: block;
+	}
+	header nav.primary ul li.active {
+		background: none;
+	}
+	header nav.primary ul li:hover a {
+		background: #2a2a2a;
+	}
+	header nav.secondary {
+		display: block;
+		background: #2a2a2a;
+	}
+	header nav.secondary ul li {
+		float: left;
+	}
+	header nav.secondary ul li a {
+		font-size: .75em;
+		padding: 0 12px;
+		line-height: 2.67;
+	}
+	header nav.secondary ul li:first-child a {
+		padding-left: 16px;
+	}
+	header nav.secondary ul li.active a {
+		color: #fcfcfc;
+	}
+	header nav.utility {
+		display: block;
+		position: absolute;
+		top: 1em;
+		right: 32px;
+	}
 }
 html.lt-ie9 blockquote {
-  margin-left: 3em;
-  margin-right: 3em;
+	margin-left: 3em;
+	margin-right: 3em;
 }
 html.lt-ie9 header > .container {
-  position: relative;
+	position: relative;
 }
 html.lt-ie9 header nav {
-  position: relative;
+	position: relative;
 }
 html.lt-ie9 header nav ul {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 html.lt-ie9 header nav ul li {
-  padding-left: 0;
-  float: left;
+	padding-left: 0;
+	float: left;
 }
 html.lt-ie9 header nav ul li ul li {
-  float: none;
+	float: none;
 }
 html.lt-ie9 header nav ul li ul li a {
-  padding-left: 0;
-  line-height: 2;
+	padding-left: 0;
+	line-height: 2;
 }
 html.lt-ie9 header nav > ul > li {
-  position: relative;
+	position: relative;
 }
 html.lt-ie9 header nav > ul > li > a {
-  padding: .25em 16px;
+	padding: .25em 16px;
 }
 html.lt-ie9 header nav > ul > li .dropdown {
-  box-shadow: 0 3px 5px 0px #1a1a1a;
-  display: none;
-  position: absolute;
-  left: 0;
-  background: #2a2a2a;
-  z-index: 1;
-  padding-left: 16px;
-  padding-right: 16px;
-  min-width: 192px;
-  -ms-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
+	box-shadow: 0 3px 5px 0px #1a1a1a;
+	display: none;
+	position: absolute;
+	left: 0;
+	background: #2a2a2a;
+	z-index: 1;
+	padding-left: 16px;
+	padding-right: 16px;
+	min-width: 192px;
+	-ms-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 html.lt-ie9 header nav > ul > li:hover .dropdown {
-  display: block;
+	display: block;
 }
 html.lt-ie9 header nav.primary ul li.active {
-  background: none;
+	background: none;
 }
 html.lt-ie9 header nav.primary ul li:hover a {
-  background: #2a2a2a;
+	background: #2a2a2a;
 }
 html.lt-ie9 header nav.secondary {
-  display: block;
-  background: #2a2a2a;
+	display: block;
+	background: #2a2a2a;
 }
 html.lt-ie9 header nav.secondary ul li {
-  float: left;
+	float: left;
 }
 html.lt-ie9 header nav.secondary ul li a {
-  font-size: .75em;
-  padding: 0 12px;
-  line-height: 2.67;
+	font-size: .75em;
+	padding: 0 12px;
+	line-height: 2.67;
 }
 html.lt-ie9 header nav.secondary ul li:first-child a {
-  padding-left: 16px;
+	padding-left: 16px;
 }
 html.lt-ie9 header nav.secondary ul li.active a {
-  color: #fcfcfc;
+	color: #fcfcfc;
 }
 html.lt-ie9 header nav.utility {
-  display: block;
-  position: absolute;
-  top: 1em;
-  right: 32px;
+	display: block;
+	position: absolute;
+	top: 1em;
+	right: 32px;
 }
 
 @media only screen and (min-width: 800px) {
-  .container {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 1024px;
-    padding-left: 16px;
-    padding-right: 16px;
-    -ms-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-  }
+	.container {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 1024px;
+		padding-left: 16px;
+		padding-right: 16px;
+		-ms-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+	}
 
-  .main {
-    width: 76%;
-    float: left;
-    -ms-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-  }
+	.main {
+		width: 76%;
+		float: left;
+		-ms-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+	}
 
-  aside.primary {
-    width: 24%;
-    float: right;
-    -ms-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-  }
+	aside.primary {
+		width: 24%;
+		float: right;
+		-ms-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+	}
 }
 html.lt-ie9 .container {
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 1024px;
-  padding-left: 16px;
-  padding-right: 16px;
-  -ms-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 1024px;
+	padding-left: 16px;
+	padding-right: 16px;
+	-ms-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 html.lt-ie9 .main {
-  width: 76%;
-  float: left;
-  -ms-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
+	width: 76%;
+	float: left;
+	-ms-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 html.lt-ie9 aside.primary {
-  width: 24%;
-  float: right;
-  -ms-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
+	width: 24%;
+	float: right;
+	-ms-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 /* IE Specific */
 html.lt-ie8 .group,
 html.lt-ie8 .container {
-  zoom: 1;
+	zoom: 1;
 }
 html.lt-ie8 button,
 html.lt-ie8 input,
 html.lt-ie8 select,
 html.lt-ie8 textarea {
-  vertical-align: middle;
+	vertical-align: middle;
 }
 html.lt-ie8 button,
 html.lt-ie8 input[type="button"],
 html.lt-ie8 input[type="reset"],
 html.lt-ie8 input[type="submit"] {
-  overflow: visible;
+	overflow: visible;
 }
 html.lt-ie8 input[type="checkbox"],
 html.lt-ie8 input[type="radio"] {
-  height: 13px;
-  width: 13px;
+	height: 13px;
+	width: 13px;
 }
 
 @media print {
-  * {
-    background: transparent !important;
-    box-shadow: none !important;
-    color: #000 !important;
-    /* Black prints faster: h5bp.com/s */
-    text-shadow: none !important;
-  }
+	* {
+		background: transparent !important;
+		box-shadow: none !important;
+		color: #000 !important;
+		/* Black prints faster: h5bp.com/s */
+		text-shadow: none !important;
+	}
 
-  a,
-  a:visited {
-    text-decoration: underline;
-  }
+	a,
+	a:visited {
+		text-decoration: underline;
+	}
 
-  a[href]:after {
-    content: " (" attr(href) ")";
-  }
+	a[href]:after {
+		content: " (" attr(href) ")";
+	}
 
-  abbr[title]:after {
-    content: " (" attr(title) ")";
-  }
+	abbr[title]:after {
+		content: " (" attr(title) ")";
+	}
 
-  a[href^="javascript:"]:after,
-  a[href^="#"]:after {
-    content: '';
-  }
+	a[href^="javascript:"]:after,
+	a[href^="#"]:after {
+		content: '';
+	}
 
-  pre,
-  blockquote {
-    border: 1px solid #999;
-    page-break-inside: avoid;
-  }
+	pre,
+	blockquote {
+		border: 1px solid #999;
+		page-break-inside: avoid;
+	}
 
-  thead {
-    display: table-header-group;
-  }
+	thead {
+		display: table-header-group;
+	}
 
-  tr,
-  img {
-    page-break-inside: avoid;
-  }
+	tr,
+	img {
+		page-break-inside: avoid;
+	}
 
-  @page {
-    margin: 0.5cm;
+	@page {
+		margin: 0.5cm;
 }
 
-  p,
-  h2,
-  h3 {
-    orphans: 3;
-    widows: 3;
-  }
+	p,
+	h2,
+	h3 {
+		orphans: 3;
+		widows: 3;
+	}
 
-  h2,
-  h3 {
-    page-break-after: avoid;
-  }
+	h2,
+	h3 {
+		page-break-after: avoid;
+	}
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -2,11 +2,7 @@
 
  * Web Fonts
  * Base
- * Grouping
- * Layout
- * Typography
- * Navigation
- * Forms
+ * Mixins
  * Messaging
  * Tables
  * Section Specific
@@ -15,540 +11,413 @@
  * Internet Explorer
  * Print Styles
  */
-
 /* = Web Fonts = */
-
-
 /* = Base = */
 a, abbr, address, article, aside, audio, b, blockquote, body, canvas, cite,
 code, dd, div, dl, dt, em, fieldset, footer, form, h1, h2, h3, h4, h5, h6,
 header, html, i, iframe, img, label, li, nav, object, ol, p, pre, section,
 span, strong, sub, sup, table, tbody, td, tfoot, th, thead, tr, ul, video {
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	margin: 0;
-	outline: 0;
-	padding: 0;
-	vertical-align: baseline;
-}
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  margin: 0;
+  outline: 0;
+  padding: 0;
+  vertical-align: baseline; }
 
 article, aside, footer, header, nav, section {
-	display: block;
-}
+  display: block; }
 
 audio, canvas, video {
-	display: inline-block;
-}
+  display: inline-block; }
 
 img {
-	-ms-interpolation-mode: bicubic;
-	max-width: 100%;
-	vertical-align: middle;
-}
+  -ms-interpolation-mode: bicubic;
+  max-width: 100%;
+  vertical-align: middle; }
 
 html {
-	background: #FCFCFC;
-	color: #555555;
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-	-ms-text-size-adjust: 100%;
-	-webkit-text-size-adjust: 100%;
-}
+  background: #FCFCFC;
+  color: #555555;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%; }
 
 body {
-	font-size: 16px;
-	line-height: 1.5;
-	min-width: 310px;
-}
+  font-size: 16px;
+  line-height: 1.5;
+  min-width: 310px; }
 
 ::-moz-selection {
-	background: #FFF6B5;
-	text-shadow: none;
-}
+  background: #FFF6B5;
+  text-shadow: none; }
 
 ::selection {
-	background: #FFF6B5;
-	text-shadow: none;
-}
+  background: #FFF6B5;
+  text-shadow: none; }
 
-
-/* = Grouping = */
+/* = Mixins = */
+.mold:before, .mold:after,
 .group:before,
-.group:after,
-.mold:before,
-.mold:after {
-	content: '';
-	display: table;
-}
-
-.group:after,
-.mold:after {
-	clear: both;
-}
+.group:after {
+  content: '';
+  display: table; }
+.mold:after,
+.group:after {
+  clear: both; }
+html.lt-ie8 .mold, html.lt-ie8
+.group {
+  zoom: 1; }
 
 .columns {
-	display: table;
-	table-layout: fixed;
-	width: 100%;
-}
-	.columns > div {
-		display: table-cell;
-	}
-
+  display: table;
+  table-layout: fixed;
+  width: 100%; }
+  .columns > div {
+    display: table-cell; }
 
 /* = Layout = */
 header.primary,
 .torso,
 footer.primary {
-	position: relative;
-	margin: 0 0 2.5em;
-}
+  position: relative;
+  margin: 0 0 2.5em; }
 
 header.primary {
-	background: #0096d2;
-}
-
-.branding {
-	padding: 1.5em 16px;
-}
-	.branding h1 {
-		margin: 0;
-	}
+  background: #0096d2; }
+  header.primary a {
+    color: #d8e7ed; }
+    header.primary a:hover {
+      color: #fcfcfc; }
+  header.primary .branding {
+    padding: 1.5em 16px; }
+    header.primary .branding h1 {
+      margin: 0; }
 
 .main,
 aside.primary {
-	padding: 0 16px;
-}
+  padding: 0 16px; }
 
 .main section,
-article {
-	margin: 0 0 3em;
-}
-
-	article .meta {
-		color: #aaa;
-		font-size: .875em;
-		line-height: 1.71;
-		margin: -1.71em 0 .57em;
-	}
+.main article {
+  margin: 0 0 3em; }
+  .main section .meta,
+  .main article .meta {
+    color: #aaa;
+    font-size: .875em;
+    line-height: 1.71;
+    margin: -1.71em 0 .57em; }
+.main aside {
+  background: #eee;
+  border-radius: 5px;
+  color: #888;
+  float: right;
+  font-size: .875em;
+  line-height: 1.43em;
+  margin: 0 0 1.333em 1.333em;
+  padding: 1.333em;
+  width: 33.33%; }
 
 aside section {
-	margin: 0 0 1.5em;
-}
+  margin: 0 0 1.5em; }
 
 footer.primary {
-	color: #999;
-	font-size: 0.875em;
-	text-align: center;
-}
-
+  color: #999;
+  font-size: 0.875em;
+  text-align: center; }
 
 /* = Typography = */
-h1,
+h1, h1 a,
 h2,
-h3,
-h4,
-h5,
-h6,
-h1 a,
 h2 a,
+h3,
 h3 a,
+h4,
 h4 a,
+h5,
 h5 a,
+h6,
 h6 a {
-	font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-weight: normal;
-}
-	h1:first-child,
-	h2:first-child,
-	h3:first-child,
-	h4:first-child,
-	h5:first-child,
-	h6:first-child {
-		margin-top: 0;
-	}
+  font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: normal; }
+h1:first-child,
+h2:first-child,
+h3:first-child,
+h4:first-child,
+h5:first-child,
+h6:first-child {
+  margin-top: 0; }
 
 h1 {
-	color: #f2006d;
-	font-size: 3em;
-	line-height: 1;
-	margin: 1.67em 0 .5em;
-}
+  color: #f2006d;
+  font-size: 3em;
+  line-height: 1;
+  margin: 1.67em 0 .5em; }
 
 h2 {
-	font-size: 2.5em;
-	line-height: 1;
-	margin: 1.2em 0 .6em;
-}
-	h1 + h2 {
-		margin-top: -.4em;
-	}
+  font-size: 2.5em;
+  line-height: 1;
+  margin: 1.2em 0 .6em; }
+
+h1 + h2 {
+  margin-top: -.4em; }
 
 h3 {
-	font-size: 1.5em;
-	line-height: 1.67;
-	margin: 2em 0 1em;
-}
-	h2 + h3 {
-		margin-top: -1em;
-	}
+  font-size: 1.5em;
+  line-height: 1.67;
+  margin: 2em 0 1em; }
+
+h2 + h3 {
+  margin-top: -1em; }
 
 h4 {
-	font-size: 1.25em;
-	line-height: 1.2;
-	margin: 1.6em 0 .8em;
-}
-	h3 + h4 {
-		margin-top: -1.2em;
-	}
+  font-size: 1.25em;
+  line-height: 1.2;
+  margin: 1.6em 0 .8em; }
+
+h3 + h4 {
+  margin-top: -1.2em; }
 
 h5 {
-	font-size: 1em;
-	line-height: 1.5;
-	margin: 0 0 .5em;
-}
-	h4 + h5,
-	h4 + h6 {
-		margin-top: -1em;
-	}
+  font-size: 1em;
+  line-height: 1.5;
+  margin: 0 0 .5em; }
+
+h4 + h5,
+h4 + h6 {
+  margin-top: -1em; }
+
 h6 {
-	font-size: .75em;
-	line-height: 1.33;
-	margin: 0 0 .67em;
-}
-	h5 + h6 {
-		margin-top: -.67em;
-	}
+  font-size: .75em;
+  line-height: 1.33;
+  margin: 0 0 .67em; }
+
+h5 + h6 {
+  margin-top: -.67em; }
 
 abbr[title] {
-	border-bottom: 1px dotted;
-}
+  border-bottom: 1px dotted; }
 
 b,
 strong {
-	font-weight: bold;
-	line-height: 22px; /*hack for mac/linux*/
-}
+  font-weight: bold;
+  line-height: 22px;
+  /*hack for mac/linux*/ }
 
 i,
 em {
-	font-style: italic;
-}
+  font-style: italic; }
 
 blockquote,
 pre {
-	color: #666;
-	clear: both;
-	margin: 0 0 1.5em;
-	padding: 0 1em;
-}
+  color: #666;
+  clear: both;
+  margin: 0 0 1.5em;
+  padding: 0 1em; }
 
 blockquote {
-	font-style: italic;
-	border-left: 1px solid #ccc;
-}
+  font-style: italic;
+  border-left: 1px solid #ccc; }
 
 .main .intro {
-	border-bottom: 1px solid #ddd;
-	margin: 0 0 2.5em;
-	padding: 0 0 1.5em;
-}
-
-	.intro p {
-		color: #888;
-		font-size: 1.25em;
-		line-height: 1.6;
-		margin: 0 0 .8em;
-	}
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 2.5em;
+  padding: 0 0 1.5em; }
+  .main .intro p {
+    color: #888;
+    font-size: 1.25em;
+    line-height: 1.6;
+    margin: 0 0 .8em; }
 
 .highlight {
-	background: #e9e9e9;
-	border-radius: 5px;
-	color: #888888;
-	font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-size: 1.5em;
-	line-height: 1.34;
-	margin: 0 0 1em;
-	padding: .67em;
-}
-
-	.highlight p {
-		margin: 0;
-	}
+  background: #e9e9e9;
+  border-radius: 5px;
+  color: #888888;
+  font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 1.5em;
+  line-height: 1.34;
+  margin: 0 0 1em;
+  padding: .67em; }
+  .highlight p {
+    margin: 0; }
 
 pre {
-	white-space: pre;
-	white-space: pre-wrap;
-	word-wrap: break-word;
-}
+  white-space: pre;
+  white-space: pre-wrap;
+  word-wrap: break-word; }
 
 pre,
 code {
-	font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace;
-}
+  font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace; }
 
 p {
-	margin: 0 0 1.5em;
-}
+  margin: 0 0 1.5em; }
 
 address {
-	margin: 0 0 1.5em;
-}
+  margin: 0 0 1.5em; }
 
 hr {
-	border: 0;
-	border-top: 1px solid #999;
-	display: block;
-	height: 0;
-	margin: 1em auto 3em;
-	width: 75%;
-}
+  border: 0;
+  border-top: 1px solid #999;
+  display: block;
+  height: 0;
+  margin: 1em auto 3em;
+  width: 75%; }
 
 a {
-	color: #0096d2;
-	text-decoration: none;
-}
-
-a:visited {
-	color: #0096d2;
-}
-
-a:hover,
-a:active {
-	color: #444;
-	outline: 0;
-}
-
-a:focus {
-	outline: thin dotted;
-}
-
-header.primary a {
-	color: #D8E7ED;
-}
-
-header.primary a:hover {
-	color: #FCFCFC;
-}
+  color: #0096d2;
+  text-decoration: none; }
+  a:visited {
+    color: #0096d2; }
+  a:hover, a:active {
+    color: #444;
+    outline: 0; }
+  a:focus {
+    outline: thin dotted; }
 
 ol,
 ul {
-	margin: 0 0 1.5em;
-	padding: 0 0 0 2em;
-}
+  margin: 0 0 1.5em;
+  padding: 0 0 0 2em; }
+
 li,
 dt,
 dd {
-	margin: 0 0 .5em;
-}
+  margin: 0 0 .5em; }
 
 ul {
-	list-style: square;
-}
+  list-style: square; }
 
 dl {
-	margin: 0 0 1.5em;
-}
+  margin: 0 0 1.5em; }
 
 dt {
-	font-weight: bold;
-	padding: 0 0 0 .5em;
-}
+  font-weight: bold;
+  padding: 0 0 0 .5em; }
 
 dd {
-	padding: 0 0 0 2em;
-}
+  padding: 0 0 0 2em; }
 
 mark {
-	background: #FFF6B5;
-}
+  background: #FFF6B5; }
 
 sup {
-	font-size: 80%;
-	vertical-align: top;
-}
+  font-size: 80%;
+  vertical-align: top; }
 
 sub {
-	font-size: 80%;
-	vertical-align: bottom;
-}
-
-.main aside {
-	background: #eee;
-	border-radius: 5px;
-	color: #888;
-	float: right;
-	font-size: .875em;
-	line-height: 1.43em;
-	margin: 0 0 1.333em 1.333em;
-	padding: 1.333em;
-	width: 33.33%;
-}
-
+  font-size: 80%;
+  vertical-align: bottom; }
 
 /* = Navigation = */
 nav ul {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-}
-nav a {
-	display: block;
-}
-
-nav li {
-	margin: 0;
-}
-
-nav li {
-	display: block;
-	white-space: nowrap;
-}
-
-nav ul:after {
-	clear: both;
-	content: '';
-	display: table;
-}
-
+  list-style: none;
+  margin: 0;
+  padding: 0; }
+  nav ul:before, nav ul:after {
+    content: '';
+    display: table; }
+  nav ul:after {
+    clear: both; }
+  html.lt-ie8 nav ul {
+    zoom: 1; }
+  nav ul li {
+    margin: 0;
+    display: block;
+    white-space: nowrap; }
+    nav ul li a {
+      display: block; }
 
 /* == top primary navigation == */
-nav.primary { }
-
-	nav.primary a {
-		color: #e9e9e9;
-		padding: .25em 16px;
-	}
-
-		nav.primary li ul li {
-			float: left;
-		}
-
-		nav.primary li ul {
-			display: none;
-		}
-
-			nav.primary li.active > a,
-		   	nav.primary li.active:hover > a	{
-				background: #555;
-			}
-
-			nav.primary > ul > li:hover > a {
-				background: #13abe8;
-			}
-				nav.primary li > ul > li:hover > a {
-					color: #fff;
-				}
-
-			nav.primary li.active ul {
-				display: block;
-				background: #555;
-			}
-
-			nav.primary ul ul {
-				margin-bottom: 1em;
-				padding-left: 1em;
-			}
-			nav.primary li ul a {
-				font-size: .75em;
-				line-height: 1.34;
-				padding: .33em 1em .33em;
-			}
-
-			nav.primary a:hover {
-				color: #e9e9e9;
-			}
+nav.primary > ul > li > a {
+  color: #e9e9e9;
+  padding: .25em 16px; }
+nav.primary > ul > li > ul {
+  margin-bottom: 1em;
+  padding-left: 1em;
+  display: none; }
+  nav.primary > ul > li > ul > li {
+    float: left; }
+    nav.primary > ul > li > ul > li > a {
+      font-size: .75em;
+      line-height: 1.34;
+      padding: .33em 1em .33em; }
+nav.primary > ul > li:hover > a {
+  background: #13abe8;
+  color: #e9e9e9; }
+nav.primary > ul > li:hover > ul > li:hover > a {
+  color: #fff; }
+nav.primary > ul > li.active > a, nav.primary > ul > li.active > a:hover {
+  background: #555; }
+nav.primary > ul > li.active > ul {
+  display: block;
+  /* MEDIA QUERY needs to turn this to none */
+  background: #555; }
 
 header nav.secondary {
-	background: #555;
-	display: none;
-}
-
-	header nav.secondary a {
-		color: #999;
-		font-size: .75em;
-		line-height: 2.67;
-		padding: 0 12px;
-	}
-		header nav.secondary li:first-child a {
-			padding: 0 12px 0 16px;
-		}
-	header nav.secondary li.active a {
-		color: #fff;
-	}
-	header nav.secondary li:hover > a {
-		color: #fff;
-	}
-
-
+  background: #555;
+  display: none; }
+  header nav.secondary ul li a {
+    color: #999;
+    font-size: .75em;
+    line-height: 2.67;
+    padding: 0 12px; }
+  header nav.secondary ul li:first-child a {
+    padding: 0 12px 0 16px; }
+  header nav.secondary ul li:hover a,
+  header nav.secondary ul li.active a {
+    color: #fff; }
 
 /* == aside secondary navigation == */
-	aside nav.secondary > ul > li {
-		border-top: 1px solid #ddd;
-	}
-		aside nav.secondary li:first-child {
-			border-top: none;
-		}
-
-		aside nav.secondary a {
-			padding: .5em 0;
-		}
-
-
-		aside nav.secondary a:hover {
-			color: #444;
-		}
-
-				aside nav.secondary li li {
-					border: none;
-				}
-
-				aside nav.secondary li li a {
-					color: #999;
-					font-size: .75em;
-					line-height: 1.34;
-					padding: .333em 0;
-				}
-
-				aside nav.secondary li li:last-child a {
-					padding: .333em 0 1em;
-				}
-
+aside nav.secondary > ul > li {
+  border-top: 1px solid #ddd; }
+  aside nav.secondary > ul > li > a {
+    padding: .5em 0; }
+    aside nav.secondary > ul > li > a:hover {
+      color: #444; }
+  aside nav.secondary > ul > li > ul > li {
+    border: none; }
+    aside nav.secondary > ul > li > ul > li > a {
+      color: #999;
+      font-size: .75em;
+      line-height: 1.34;
+      padding: .333em 0; }
+  aside nav.secondary > ul > li > ul > li:last-child > a {
+    padding: .333em 0 1em; }
+aside nav.secondary > ul > li:first-child {
+  border-top: none; }
 
 /* == utility navigation == */
 header nav.utility {
-	display: none;
-	position: absolute;
-	right: 0;
-	text-align: right;
-	top: 1em;
-}
-	header nav.utility > ul > li {
-		float: left;
-	}
-
-	header nav.utility > ul {
-		position: relative;
-	}
-
-	header nav.utility a {
-		font-size: .75em;
-		line-height: 2;
-		padding: 0 .667em;
-	}
+  display: none;
+  position: absolute;
+  right: 0;
+  text-align: right;
+  top: 1em; }
+  header nav.utility > ul {
+    position: relative; }
+    header nav.utility > ul > li {
+      float: left; }
+  header nav.utility a {
+    font-size: .75em;
+    line-height: 2;
+    padding: 0 .667em; }
 
 /* = Forms = */
 button,
 input,
 select,
 textarea {
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-size: 100%;
-}
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 100%; }
+  html.lt-ie8 button, html.lt-ie8
+  input, html.lt-ie8
+  select, html.lt-ie8
+  textarea {
+    vertical-align: middle; }
 
 select {
-	margin: .5em 0;
-}
+  margin: .5em 0; }
 
 .button,
 .checkboxes,
@@ -560,513 +429,364 @@ select {
 .submit,
 .text,
 .textarea {
-	margin-bottom: 1.5em;
-}
+  margin-bottom: 1.5em; }
 
 label {
-	color: #333;
-	cursor: pointer;
-	display: block;
-	font-weight: bold;
-	line-height: 2;
-	margin: 0;
-}
+  color: #333;
+  cursor: pointer;
+  display: block;
+  font-weight: bold;
+  line-height: 2;
+  margin: 0; }
 
 span.required {
-	color: #ac181b;
-}
+  color: #ac181b; }
 
 fieldset .help {
-	color: #999;
-	display: block;
-	font-size: .75em;
-	line-height: 1.34;
-	margin: 0;
-	padding: 0;
-}
+  color: #999;
+  display: block;
+  font-size: .75em;
+  line-height: 1.34;
+  margin: 0;
+  padding: 0; }
 
 .radio,
 .checkbox {
-	font-weight: normal;
-	margin: 0 0 .5em;
-	padding: 0 0 0 .25em;
-}
+  font-weight: normal;
+  margin: 0 0 .5em;
+  padding: 0 0 0 .25em; }
+
+html.lt-ie8 input[type="checkbox"], html.lt-ie8
+input[type="radio"] {
+  height: 13px;
+  width: 13px; }
 
 input[type="text"],
 input[type="password"],
 textarea {
-	border-radius: 2px;
-	border: 0;
-	box-shadow: 0 1px 4px 0 #848484 inset;
-	color: #333;
-	display: block;
-	font-size: 1em;
-	line-height: 2;
-	margin: 0;
-	padding: 0 1%;
-	width: 98%;
-}
+  border-radius: 2px;
+  border: 0;
+  box-shadow: 0 1px 4px 0 #848484 inset;
+  color: #333;
+  display: block;
+  font-size: 1em;
+  line-height: 2;
+  margin: 0;
+  padding: 0 1%;
+  width: 98%; }
+  html.lt-ie9 input[type="text"], html.lt-ie9
+  input[type="password"], html.lt-ie9
+  textarea {
+    border: 1px solid #848484; }
 
 input[type="file"] {
-	color: #333;
-	display: block;
-	font-size: 1em;
-	line-height: 2;
-	margin: 0;
-	padding: 0;
-	width: 100%;
-}
+  color: #333;
+  display: block;
+  font-size: 1em;
+  line-height: 2;
+  margin: 0;
+  padding: 0;
+  width: 100%; }
 
 textarea {
-	height: 12em;
-	overflow: auto;
-	resize: vertical;
-}
+  height: 12em;
+  overflow: auto;
+  resize: vertical; }
 
 input[type="checkbox"],
 input[type="radio"] {
-	-ms-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
-}
+  -ms-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box; }
 
 button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
-	-webkit-appearance: button;
-	cursor: pointer;
-}
+  -webkit-appearance: button;
+  cursor: pointer; }
+  html.lt-ie8 button, html.lt-ie8
+  input[type="button"], html.lt-ie8
+  input[type="reset"], html.lt-ie8
+  input[type="submit"] {
+    overflow: visible; }
 
 button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"],
 a.button {
-	background: #0394cd;
-	border-radius: 3px;
-	border: none;
-	color: #fff;
-	display: inline-block;
-	font-weight: bold;
-	line-height: 1;
-	margin: 0 .5em .5em 0;
-	padding: .5em .5em;
-	text-align: center;
-}
-
-button:hover,
-input[type="button"]:hover,
-input[type="reset"]:hover,
-input[type="submit"]:hover,
-a.button:hover {
-	background: #13ABE8;
-	cursor: pointer;
-}
-
-button:focus,
-input[type="button"]:focus,
-input[type="reset"]:focus,
-input[type="submit"]:focus,
-a.button:focus {
-	background: #0084B8;
-}
+  background: #0394cd;
+  border-radius: 3px;
+  border: none;
+  color: #fff;
+  display: inline-block;
+  font-weight: bold;
+  line-height: 1;
+  margin: 0 .5em .5em 0;
+  padding: .5em .5em;
+  text-align: center; }
+  button:hover,
+  input[type="button"]:hover,
+  input[type="reset"]:hover,
+  input[type="submit"]:hover,
+  a.button:hover {
+    background: #13ABE8;
+    cursor: pointer; }
+  button:focus,
+  input[type="button"]:focus,
+  input[type="reset"]:focus,
+  input[type="submit"]:focus,
+  a.button:focus {
+    background: #0084B8; }
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
-	border: 0;
-	padding: 0;
-}
-
+  border: 0;
+  padding: 0; }
 
 /* = Messaging = */
 .messaging {
-	border-radius: 5px;
-	margin: 0 0 1.5em;
-	padding: 1em 3.25em;
-	position: relative;
-}
-
-.messaging a {
-	color: inherit;
-	text-decoration: underline;
-}
-
-	.messaging:before {
-		background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QEQAh0Zl47LzAAAAuJJREFUWMPtmO9H3VEcx9/t5nK5ZNGMy7iJiBgxRkT2YESPNnEf7VHsUUSKnk00MSIuoz9gGqNEbItNjFhGbEYaEc0od5qItteenG87O31/nO+93x5s9eHwdb6f7+uc8zmfz+d8P0f6rwXoBHaAPeBu1vA1/sg+UMwKXOGsTGcBLgK7BnhoTANwDHQ0Cp80sM9Ai+mrmr7lRsAlM1uAp1Z/n2WevjjGlZh3M5KCjftp9dvPs0AuFRzolVTxWOBNScNpZz6bwoJTwX4kwoGKpJ4U8FZJE4lwExwzdez/aJhrujOflFQK+fi69Rzm3/lYUwIdJjiipApMW+4ZJv1RM58yM4iSvKTvpkXJkzOuCfQSLy8t3YEE3YenMzcjzSVsmO1qRQ/XbA1mMoafrAHzQM1Dd16SmoAvksoZny8/JF3TpVwcKUh6IOm5pF1JWG1H0jPzvpAGmpM0IqnmAKNazSS8vE9ufuMJddumpBtxiWm9TnDQ9iJSsuY8Pj6QdF/SeIzOR3cfypKOPeCv7GQa0/469qZTLP2xpIUEnX1JhWYD9zmQX0vaMLp3PByjtznkjIwDB8vdltSe8E1n8PDe0ySBHHjojgVn6CcPs2xYJrzqof81gC952lwe9g7krR3yHxKWGUAXPEyy6o7UJ+kk5oNxo9du3DFK70TS7bClDHsE0XaCzmicre5JOqoztzzy2Yyyyddp4f1pcnurKQJeSDp0QL98NrJe6TKrc004FCg0ZTBI0YR6j/n9XrIC7lL+0SuTbmDkPMAl6/Jh+fTHPwNwC7Dp/PivZAEuAKsOeBcoNQrOAYsOuAZ0ZzHrqgM+dmvQesETIQVWJQtw2H3XRBpAV0R/f0j5Xk0DHgpu3+wy2wSJW38uxt0SueAe4Mj2V+PHdpAEsg4UfMFtIQCArZAg2QLa0pgjD8x5lN3f6r5PBAZjavsj4Faj7lYG3oUEyWBWCSlvPCa7IAkZZOBc8vTFlt90PErGWW5fZgAAAABJRU5ErkJggg==);
-		background-position: 0 0;
-		background-repeat: no-repeat;
-		content:'';
-		display: block;
-		height: 23px;
-		left: 1em;
-		position: absolute;
-		top: 1em;
-		width: 23px;
-	}
-
-	.error:before {
-		background-position: 0 0;
-	}
-
-	.success:before {
-		background-position: 0 -46px;
-	}
-
-	.info:before {
-		background-position: 0 -23px;
-	}
-
-.success {
-	background: #40B36E;
-	color: #FCFCFC;
-}
-
-.error {
-	background: #C44949;
-	color: #FCFCFC;
-}
-
-.info {
-	background: #CCCCCC;
-	color: #555555;
-}
-
+  border-radius: 5px;
+  margin: 0 0 1.5em;
+  padding: 1em 3.25em;
+  position: relative; }
+  .messaging:before {
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QEQAh0Zl47LzAAAAuJJREFUWMPtmO9H3VEcx9/t5nK5ZNGMy7iJiBgxRkT2YESPNnEf7VHsUUSKnk00MSIuoz9gGqNEbItNjFhGbEYaEc0od5qItteenG87O31/nO+93x5s9eHwdb6f7+uc8zmfz+d8P0f6rwXoBHaAPeBu1vA1/sg+UMwKXOGsTGcBLgK7BnhoTANwDHQ0Cp80sM9Ai+mrmr7lRsAlM1uAp1Z/n2WevjjGlZh3M5KCjftp9dvPs0AuFRzolVTxWOBNScNpZz6bwoJTwX4kwoGKpJ4U8FZJE4lwExwzdez/aJhrujOflFQK+fi69Rzm3/lYUwIdJjiipApMW+4ZJv1RM58yM4iSvKTvpkXJkzOuCfQSLy8t3YEE3YenMzcjzSVsmO1qRQ/XbA1mMoafrAHzQM1Dd16SmoAvksoZny8/JF3TpVwcKUh6IOm5pF1JWG1H0jPzvpAGmpM0IqnmAKNazSS8vE9ufuMJddumpBtxiWm9TnDQ9iJSsuY8Pj6QdF/SeIzOR3cfypKOPeCv7GQa0/469qZTLP2xpIUEnX1JhWYD9zmQX0vaMLp3PByjtznkjIwDB8vdltSe8E1n8PDe0ySBHHjojgVn6CcPs2xYJrzqof81gC952lwe9g7krR3yHxKWGUAXPEyy6o7UJ+kk5oNxo9du3DFK70TS7bClDHsE0XaCzmicre5JOqoztzzy2Yyyyddp4f1pcnurKQJeSDp0QL98NrJe6TKrc004FCg0ZTBI0YR6j/n9XrIC7lL+0SuTbmDkPMAl6/Jh+fTHPwNwC7Dp/PivZAEuAKsOeBcoNQrOAYsOuAZ0ZzHrqgM+dmvQesETIQVWJQtw2H3XRBpAV0R/f0j5Xk0DHgpu3+wy2wSJW38uxt0SueAe4Mj2V+PHdpAEsg4UfMFtIQCArZAg2QLa0pgjD8x5lN3f6r5PBAZjavsj4Faj7lYG3oUEyWBWCSlvPCa7IAkZZOBc8vTFlt90PErGWW5fZgAAAABJRU5ErkJggg==);
+    background-position: 0 0;
+    background-repeat: no-repeat;
+    content: '';
+    display: block;
+    height: 23px;
+    left: 1em;
+    position: absolute;
+    top: 1em;
+    width: 23px; }
+  .messaging a {
+    color: inherit;
+    text-decoration: underline; }
+  .messaging.error {
+    background: #C44949;
+    color: #FCFCFC; }
+    .messaging.error:before {
+      background-position: 0 0; }
+  .messaging.success {
+    background: #40B36E;
+    color: #FCFCFC; }
+    .messaging.success:before {
+      background-position: 0 -46px; }
+  .messaging.info {
+    background: #CCCCCC;
+    color: #555555; }
+    .messaging.info:before {
+      background-position: 0 -23px; }
 
 /* = Tables = */
 caption {
-	font-size: .75em;
-	line-height: 1.33em;
-}
+  font-size: .75em;
+  line-height: 1.33em; }
 
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
-	margin: 0 0 1.5em;
-	width: 100%;
-}
-
-	thead { }
-
-		thead th {
-			border-bottom: 1px solid #999;
-		}
-
-	th {
-		font-weight: bold;
-	}
-
-	td,
-	th {
-		padding: .25em .5em;
-		text-align: left;
-		vertical-align: top;
-	}
-
+  border-collapse: collapse;
+  border-spacing: 0;
+  margin: 0 0 1.5em;
+  width: 100%; }
+  table thead th {
+    border-bottom: 1px solid #999; }
+  table td,
+  table th {
+    padding: .25em .5em;
+    text-align: left;
+    vertical-align: top; }
+  table th {
+    font-weight: bold; }
 
 /* = Section Specific = */
-
-
 /* = Page Specific = */
-
-
 /* = Media Queries = */
-
-/* tablets, landscape phones, small desktops */
 @media only screen and (min-width: 640px) {
-	header nav.utility {
-		display: block;
-	}
+  header nav.utility {
+    display: block; }
 
-	header nav li {
-		float: left;
-		position: relative;
-		white-space: nowrap;
-	}
+  nav.primary,
+  header nav.secondary {
+    display: block; }
+    nav.primary > ul > li,
+    header nav.secondary > ul > li {
+      float: left;
+      position: relative;
+      white-space: nowrap; }
+      nav.primary > ul > li > a:hover,
+      header nav.secondary > ul > li > a:hover {
+        color: #ffffff; }
+      nav.primary > ul > li > ul,
+      header nav.secondary > ul > li > ul {
+        display: none;
+        left: 0;
+        overflow: hidden;
+        position: absolute;
+        width: 200px;
+        background: #13abe8;
+        margin: 0;
+        padding: 0; }
+        nav.primary > ul > li > ul > li,
+        header nav.secondary > ul > li > ul > li {
+          float: none;
+          min-width: 100%; }
+          nav.primary > ul > li > ul > li > a,
+          header nav.secondary > ul > li > ul > li > a {
+            padding: .6em 1.33em .6em;
+            font-size: .875em;
+            line-height: 2; }
+    nav.primary > ul > li:hover > a,
+    header nav.secondary > ul > li:hover > a {
+      border-top-left-radius: 6px;
+      border-top-right-radius: 6px; }
+    nav.primary > ul > li:hover > ul,
+    header nav.secondary > ul > li:hover > ul {
+      display: block;
+      z-index: 2;
+      border-bottom-left-radius: 6px;
+      border-bottom-right-radius: 6px; }
+    nav.primary > ul > li.active > a,
+    header nav.secondary > ul > li.active > a {
+      border-top-left-radius: 6px;
+      border-top-right-radius: 6px; }
+    nav.primary > ul > li.active > ul,
+    header nav.secondary > ul > li.active > ul {
+      display: none; } }
+html.lt-ie9 header nav.utility {
+  display: block; }
+html.lt-ie9 nav.primary,
+html.lt-ie9 header nav.secondary {
+  display: block; }
+  html.lt-ie9 nav.primary > ul > li,
+  html.lt-ie9 header nav.secondary > ul > li {
+    float: left;
+    position: relative;
+    white-space: nowrap; }
+    html.lt-ie9 nav.primary > ul > li > a:hover,
+    html.lt-ie9 header nav.secondary > ul > li > a:hover {
+      color: #ffffff; }
+    html.lt-ie9 nav.primary > ul > li > ul,
+    html.lt-ie9 header nav.secondary > ul > li > ul {
+      display: none;
+      left: 0;
+      overflow: hidden;
+      position: absolute;
+      width: 200px;
+      background: #13abe8;
+      margin: 0;
+      padding: 0; }
+      html.lt-ie9 nav.primary > ul > li > ul > li,
+      html.lt-ie9 header nav.secondary > ul > li > ul > li {
+        float: none;
+        min-width: 100%; }
+        html.lt-ie9 nav.primary > ul > li > ul > li > a,
+        html.lt-ie9 header nav.secondary > ul > li > ul > li > a {
+          padding: .6em 1.33em .6em;
+          font-size: .875em;
+          line-height: 2; }
+  html.lt-ie9 nav.primary > ul > li:hover > a,
+  html.lt-ie9 header nav.secondary > ul > li:hover > a {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px; }
+  html.lt-ie9 nav.primary > ul > li:hover > ul,
+  html.lt-ie9 header nav.secondary > ul > li:hover > ul {
+    display: block;
+    z-index: 2;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px; }
+  html.lt-ie9 nav.primary > ul > li.active > a,
+  html.lt-ie9 header nav.secondary > ul > li.active > a {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px; }
+  html.lt-ie9 nav.primary > ul > li.active > ul,
+  html.lt-ie9 header nav.secondary > ul > li.active > ul {
+    display: none; }
 
-	header nav li ul,
-	nav.primary li.active ul {
-		display: none;
-		left: 0;
-		overflow: hidden;
-		position: absolute;
-		width: 200px;
-	}
-
-		nav.primary li ul a {
-			padding: .6em 1.33em .6em;
-		}
-
-
-	header li:hover > ul {
-		display: block;
-		z-index: 2;
-	}
-
-		header li li {
-			float: none;
-			min-width: 100%;
-		}
-
-		nav.primary > ul > li.active > a,
-		nav.primary > ul > li:hover > a {
-			border-top-left-radius: 6px;
-			border-top-right-radius: 6px;
-		}
-
-		nav.primary > ul > li a:hover {
-			color: #FFFFFF;
-		}
-
-		nav.primary > ul > li:hover > ul {
-			border-bottom-left-radius: 6px;
-			border-bottom-right-radius: 6px;
-		}
-
-		header nav.secondary {
-			display: block;
-		}
-
-		header nav li ul {
-			background: #13ABE8;
-			margin: 0;
-			padding: 0;
-		}
-		
-		header nav li ul a {
-			font-size: .875em;
-			line-height: 2;
-		}
-
-		header nav li ul li {
-			float: none;
-		}
-
-			header nav li ul a {
-				padding: 0 16px 0 32px;
-			}
-
-			nav.primary ul ul {
-				padding: 0;
-			}
-}
 @media only screen and (min-width: 800px) {
-	.branding {
-		padding: 1.75em 0;
-	}
+  .branding {
+    padding: 1.75em 0; }
 
-	aside.primary {
-		padding: 0 1em 0 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-		width: 192px;
-	}
+  aside.primary {
+    padding: 0 1em 0 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 192px; }
 
-	.main {
-		margin-right: 192px;
-		padding: 0 32px 0 0;
-	}
+  .main {
+    margin-right: 192px;
+    padding: 0 32px 0 0; }
 
-	.mold {
-		margin: 0 auto;
-		max-width: 1024px;
-		padding: 0 16px;
-		position: relative;
-	}
-}
-
+  .mold {
+    margin: 0 auto;
+    max-width: 1024px;
+    padding: 0 16px;
+    position: relative; } }
+html.lt-ie9 .branding {
+  padding: 1.75em 0; }
+html.lt-ie9 aside.primary {
+  padding: 0 1em 0 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 192px; }
+html.lt-ie9 .main {
+  margin-right: 192px;
+  padding: 0 32px 0 0; }
+html.lt-ie9 .mold {
+  margin: 0 auto;
+  max-width: 1024px;
+  padding: 0 16px;
+  position: relative; }
 
 /* = IE Specific = */
-/* IE6, IE7 */
-html.lt-ie8 .group,
-html.lt-ie8 .mold,
-html.lt-ie8 header nav {
-	zoom: 1;
-}
-
-html.lt-ie8 button,
-html.lt-ie8 input,
-html.lt-ie8 select,
-html.lt-ie8 textarea {
-	vertical-align: middle;
-}
-
-html.lt-ie8 button,
-html.lt-ie8 input[type="button"],
-html.lt-ie8 input[type="reset"],
-html.lt-ie8 input[type="submit"] {
-	overflow: visible;
-}
-
-html.lt-ie8 input[type="checkbox"],
-html.lt-ie8 input[type="radio"] {
-	height: 13px;
-	width: 13px;
-}
-
-/* IE6, IE7, IE8 */
-html.lt-ie9 input[type="text"],
-html.lt-ie9 input[type="password"],
-html.lt-ie9 textarea {
-	border: 1px solid #848484;
-}
-
-/* Navigation */
-html.lt-ie9 header nav.utility {
-	display: block;
-}
-
-html.lt-ie9 header nav li {
-	float: left;
-	position: relative;
-	white-space: nowrap;
-}
-
-html.lt-ie9 header nav li ul,
-html.lt-ie9 nav.primary li.active ul {
-	display: none;
-	left: 0;
-	overflow: hidden;
-	position: absolute;
-	width: 200px;
-}
-
-	html.lt-ie9 nav.primary li ul a {
-		padding: .6em 1.33em .6em;
-	}
-
-html.lt-ie9 header li:hover > ul {
-	display: block;
-	z-index: 2;
-}
-
-	html.lt-ie9 header li li {
-		float: none;
-		min-width: 100%;
-	}
-
-	html.lt-ie9 nav.primary > ul > li.active > a,
-	html.lt-ie9 nav.primary > ul > li:hover > a {
-		border-top-left-radius: 6px;
-		border-top-right-radius: 6px;
-	}
-
-	html.lt-ie9 nav.primary > ul > li a:hover {
-		color: #FFFFFF;
-	}
-
-	html.lt-ie9 nav.primary > ul > li:hover > ul {
-		border-bottom-left-radius: 6px;
-		border-bottom-right-radius: 6px;
-	}
-
-	html.lt-ie9 header nav.secondary {
-		display: block;
-	}
-
-	html.lt-ie9 header nav li ul {
-		background: #13ABE8;
-		margin: 0;
-		padding: 0;
-	}
-	
-	html.lt-ie9 header nav li ul a {
-		font-size: .875em;
-		line-height: 2;
-	}
-
-	html.lt-ie9 header nav li ul li {
-		float: none;
-	}
-
-		html.lt-ie9 header nav li ul a {
-			padding: 0 16px 0 32px;
-		}
-
-		html.lt-ie9 nav.primary ul ul {
-			padding: 0;
-		}
-html.lt-ie9 .branding {
-	padding: 1.75em 0;
-}
-
-html.lt-ie9 aside.primary {
-	padding: 0 1em 0 0;
-	position: absolute;
-	right: 0;
-	top: 0;
-	width: 192px;
-}
-
-html.lt-ie9 .main {
-	margin-right: 192px;
-	padding: 0 32px 0 0;
-}
-
-html.lt-ie9 .mold {
-	margin: 0 auto;
-	max-width: 1024px;
-	padding: 0 16px;
-	position: relative;
-}
-
 /* = Print Styles = */
 @media print {
-	* {
-		background: transparent !important;
-		box-shadow: none !important;
-		color: #000 !important; /* Black prints faster: h5bp.com/s */
-		text-shadow: none !important;
-	}
+  * {
+    background: transparent !important;
+    box-shadow: none !important;
+    color: #000 !important;
+    text-shadow: none !important; }
 
-	a,
-	a:visited {
-		text-decoration: underline;
-	}
+  a,
+  a:visited {
+    text-decoration: underline; }
 
-	a[href]:after {
-		content: " (" attr(href) ")";
-	}
+  a[href]:after {
+    content: " (" attr(href) ")"; }
 
-	abbr[title]:after {
-		content: " (" attr(title) ")";
-	}
+  abbr[title]:after {
+    content: " (" attr(title) ")"; }
 
-	a[href^="javascript:"]:after,
-	a[href^="#"]:after {
-		content: '';
-	}
+  a[href^="javascript:"]:after,
+  a[href^="#"]:after {
+    content: ''; }
 
-	pre,
-	blockquote {
-		border: 1px solid #999;
-		page-break-inside: avoid;
-	}
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid; }
 
-	thead {
-		display: table-header-group;
-	}
+  thead {
+    display: table-header-group; }
 
-	tr,
-	img {
-		page-break-inside: avoid;
-	}
+  tr,
+  img {
+    page-break-inside: avoid; }
 
-	@page {
-		margin: 0.5cm;
-	}
+  @page {
+    margin: 0.5cm; }
 
-	p,
-	h2,
-	h3 {
-		orphans: 3;
-		widows: 3;
-	}
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3; }
 
-	h2,
-	h3 {
-		page-break-after: avoid;
-	}
-}
+  h2,
+  h3 {
+    page-break-after: avoid; } }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,8 +1,15 @@
+@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600);
 /* = Table of Contents =
 
+ * Colors
  * Web Fonts
  * Base
  * Mixins
+ * Grouping
+ * Layout
+ * Typography
+ * Navigation
+ * Forms
  * Messaging
  * Tables
  * Section Specific
@@ -11,6 +18,7 @@
  * Internet Explorer
  * Print Styles
  */
+/* = Colors = */
 /* = Web Fonts = */
 /* = Base = */
 a, abbr, address, article, aside, audio, b, blockquote, body, canvas, cite,
@@ -23,401 +31,467 @@ span, strong, sub, sup, table, tbody, td, tfoot, th, thead, tr, ul, video {
   margin: 0;
   outline: 0;
   padding: 0;
-  vertical-align: baseline; }
+  vertical-align: baseline;
+}
 
 article, aside, footer, header, nav, section {
-  display: block; }
+  display: block;
+}
 
 audio, canvas, video {
-  display: inline-block; }
+  display: inline-block;
+}
 
 img {
   -ms-interpolation-mode: bicubic;
   max-width: 100%;
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 html {
-  background: #FCFCFC;
+  background: #fcfcfc;
   color: #555555;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: Arial, Helvetica, sans-serif;
   -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%; }
+  -webkit-text-size-adjust: 100%;
+}
 
 body {
   font-size: 16px;
   line-height: 1.5;
-  min-width: 310px; }
+  min-width: 310px;
+}
 
 ::-moz-selection {
-  background: #FFF6B5;
-  text-shadow: none; }
+  background: #fff6b5;
+  text-shadow: none;
+}
 
 ::selection {
-  background: #FFF6B5;
-  text-shadow: none; }
+  background: #fff6b5;
+  text-shadow: none;
+}
 
 /* = Mixins = */
-.mold:before, .mold:after,
-.group:before,
-.group:after {
+/* = Grouping = */
+.group:before, .group:after,
+.container:before,
+.container:after {
   content: '';
-  display: table; }
-.mold:after,
-.group:after {
-  clear: both; }
-html.lt-ie8 .mold, html.lt-ie8
-.group {
-  zoom: 1; }
+  display: table;
+}
+.group:after,
+.container:after {
+  clear: both;
+}
 
 .columns {
   display: table;
   table-layout: fixed;
-  width: 100%; }
-  .columns > div {
-    display: table-cell; }
+  width: 100%;
+}
+.columns > * {
+  display: table-cell;
+  width: 100%;
+}
 
 /* = Layout = */
 header.primary,
 .torso,
 footer.primary {
   position: relative;
-  margin: 0 0 2.5em; }
+  margin-bottom: 2.5em;
+}
 
 header.primary {
-  background: #0096d2; }
-  header.primary a {
-    color: #d8e7ed; }
-    header.primary a:hover {
-      color: #fcfcfc; }
-  header.primary .branding {
-    padding: 1.5em 16px; }
-    header.primary .branding h1 {
-      margin: 0; }
+  background: #1a1a1a;
+}
+header.primary .branding {
+  padding: 1.5em 16px;
+}
+header.primary .branding h1 {
+  margin: 0;
+}
+header.primary .branding h1 a {
+  color: #fcfcfc;
+}
 
-.main,
-aside.primary {
-  padding: 0 16px; }
-
-.main section,
-.main article {
-  margin: 0 0 3em; }
-  .main section .meta,
-  .main article .meta {
-    color: #aaa;
-    font-size: .875em;
-    line-height: 1.71;
-    margin: -1.71em 0 .57em; }
-.main aside {
+.torso .main,
+.torso aside.primary {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.torso .main article .meta,
+.torso aside.primary article .meta {
+  color: #888888;
+  font-size: .875em;
+  margin-top: -.5em;
+  margin-bottom: 1em;
+}
+.torso .main article,
+.torso .main section {
+  margin-bottom: 3em;
+}
+.torso .main aside {
   background: #eee;
   border-radius: 5px;
   color: #888;
   float: right;
   font-size: .875em;
   line-height: 1.43em;
-  margin: 0 0 1.333em 1.333em;
+  margin-bottom: 1.333em;
+  margin-left: 1.333em;
   padding: 1.333em;
-  width: 33.33%; }
-
-aside section {
-  margin: 0 0 1.5em; }
+  text-shadow: 0px 1px 0px #fff;
+  width: 33.33%;
+}
+.torso aside.primary article,
+.torso aside.primary section {
+  margin-bottom: 1.5em;
+}
 
 footer.primary {
-  color: #999;
+  color: #888888;
   font-size: 0.875em;
-  text-align: center; }
+  padding-left: 16px;
+  padding-right: 16px;
+}
 
 /* = Typography = */
-h1, h1 a,
+h1,
 h2,
-h2 a,
 h3,
-h3 a,
 h4,
-h4 a,
 h5,
-h5 a,
-h6,
-h6 a {
-  font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: normal; }
+h6 {
+  font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: normal;
+}
 h1:first-child,
 h2:first-child,
 h3:first-child,
 h4:first-child,
 h5:first-child,
 h6:first-child {
-  margin-top: 0; }
+  margin-top: 0;
+}
 
 h1 {
   color: #f2006d;
   font-size: 3em;
-  line-height: 1;
-  margin: 1.67em 0 .5em; }
+  line-height: 1.2;
+  margin-top: 1.67em;
+  margin-bottom: .5em;
+}
 
 h2 {
   font-size: 2.5em;
-  line-height: 1;
-  margin: 1.2em 0 .6em; }
+  line-height: 1.2;
+  margin-top: 1.2em;
+  margin-bottom: .4em;
+}
 
 h1 + h2 {
-  margin-top: -.4em; }
+  margin-top: -.2em;
+}
 
 h3 {
   font-size: 1.5em;
-  line-height: 1.67;
-  margin: 2em 0 1em; }
+  line-height: 1.3;
+  margin-top: 1.8em;
+  margin-bottom: .4em;
+}
 
 h2 + h3 {
-  margin-top: -1em; }
+  margin-top: -.4em;
+  margin-bottom: .2em;
+}
 
 h4 {
   font-size: 1.25em;
-  line-height: 1.2;
-  margin: 1.6em 0 .8em; }
+  line-height: 1.4;
+  margin-top: 1.8em;
+  margin-bottom: .4em;
+}
 
 h3 + h4 {
-  margin-top: -1.2em; }
+  margin-top: -.3em;
+}
 
 h5 {
   font-size: 1em;
-  line-height: 1.5;
-  margin: 0 0 .5em; }
+  margin-top: 1.8em;
+  margin-bottom: .4em;
+}
 
-h4 + h5,
-h4 + h6 {
-  margin-top: -1em; }
+h4 + h5 {
+  margin-top: -.3em;
+}
 
 h6 {
-  font-size: .75em;
-  line-height: 1.33;
-  margin: 0 0 .67em; }
+  font-size: .9em;
+  margin-top: 1.8em;
+  margin-bottom: .4em;
+}
 
 h5 + h6 {
-  margin-top: -.67em; }
+  margin-top: -.2em;
+}
 
 abbr[title] {
-  border-bottom: 1px dotted; }
+  border-bottom: 1px dotted;
+}
 
 b,
 strong {
   font-weight: bold;
-  line-height: 22px;
-  /*hack for mac/linux*/ }
+}
 
 i,
 em {
-  font-style: italic; }
+  font-style: italic;
+}
 
 blockquote,
 pre {
-  color: #666;
+  color: #888888;
+  margin-bottom: 1.5em;
+}
+blockquote:before, blockquote:after,
+pre:before,
+pre:after {
+  content: '';
+  display: table;
+}
+blockquote:after,
+pre:after {
   clear: both;
-  margin: 0 0 1.5em;
-  padding: 0 1em; }
+}
 
 blockquote {
   font-style: italic;
-  border-left: 1px solid #ccc; }
+  border-left: 1px solid #cccccc;
+  margin-left: 2em;
+  margin-right: 1em;
+  padding-left: 1em;
+  padding-right: 1em;
+}
 
 .main .intro {
-  border-bottom: 1px solid #ddd;
-  margin: 0 0 2.5em;
-  padding: 0 0 1.5em; }
-  .main .intro p {
-    color: #888;
-    font-size: 1.25em;
-    line-height: 1.6;
-    margin: 0 0 .8em; }
-
-.highlight {
+  border-bottom: 1px solid #cccccc;
+  margin-bottom: 2.5em;
+  padding-bottom: 1.5em;
+}
+.main .intro p {
+  color: #888;
+  font-size: 1.25em;
+  line-height: 1.6;
+  margin-bottom: .8em;
+}
+.main .highlight {
   background: #e9e9e9;
   border-radius: 5px;
-  color: #888888;
-  font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #888;
   font-size: 1.5em;
   line-height: 1.34;
-  margin: 0 0 1em;
-  padding: .67em; }
-  .highlight p {
-    margin: 0; }
+  margin-bottom: 1em;
+  padding: .67em;
+  text-shadow: 0px 1px 0px #fff;
+}
+.main .highlight p {
+  margin-bottom: 0;
+}
+
+pre,
+code {
+  font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace;
+  font-size: .9em;
+}
 
 pre {
   white-space: pre;
   white-space: pre-wrap;
-  word-wrap: break-word; }
-
-pre,
-code {
-  font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace; }
+  word-wrap: break-word;
+}
 
 p {
-  margin: 0 0 1.5em; }
+  margin-bottom: 1.5em;
+}
 
 address {
-  margin: 0 0 1.5em; }
+  margin-bottom: 1.5em;
+}
 
 hr {
   border: 0;
   border-top: 1px solid #999;
   display: block;
   height: 0;
-  margin: 1em auto 3em;
-  width: 75%; }
+  margin: 2em auto 3em;
+  width: 75%;
+}
 
 a {
   color: #0096d2;
-  text-decoration: none; }
-  a:visited {
-    color: #0096d2; }
-  a:hover, a:active {
-    color: #444;
-    outline: 0; }
-  a:focus {
-    outline: thin dotted; }
+  text-decoration: none;
+}
+a:visited {
+  color: #0096d2;
+}
+a:hover, a:active {
+  color: #888888;
+  outline: 0;
+}
+a:focus {
+  outline: thin dotted;
+}
+
+ol,
+ul,
+dl {
+  margin-bottom: 1.5em;
+}
 
 ol,
 ul {
-  margin: 0 0 1.5em;
-  padding: 0 0 0 2em; }
-
-li,
-dt,
-dd {
-  margin: 0 0 .5em; }
+  padding-left: 2em;
+}
+ol li,
+ol dt,
+ol dd,
+ul li,
+ul dt,
+ul dd {
+  margin-bottom: .5em;
+}
 
 ul {
-  list-style: square; }
-
-dl {
-  margin: 0 0 1.5em; }
+  list-style: disc;
+}
 
 dt {
   font-weight: bold;
-  padding: 0 0 0 .5em; }
+  padding-left: .5em;
+}
 
 dd {
-  padding: 0 0 0 2em; }
+  padding-left: 2em;
+}
 
-mark {
-  background: #FFF6B5; }
-
-sup {
-  font-size: 80%;
-  vertical-align: top; }
-
+sup,
 sub {
   font-size: 80%;
-  vertical-align: bottom; }
+}
+
+sup {
+  vertical-align: top;
+}
+
+sub {
+  vertical-align: bottom;
+}
 
 /* = Navigation = */
 nav ul {
   list-style: none;
-  margin: 0;
-  padding: 0; }
-  nav ul:before, nav ul:after {
-    content: '';
-    display: table; }
-  nav ul:after {
-    clear: both; }
-  html.lt-ie8 nav ul {
-    zoom: 1; }
-  nav ul li {
-    margin: 0;
-    display: block;
-    white-space: nowrap; }
-    nav ul li a {
-      display: block; }
-
-/* == top primary navigation == */
-nav.primary > ul > li > a {
-  color: #e9e9e9;
-  padding: .25em 16px; }
-nav.primary > ul > li > ul {
-  margin-bottom: 1em;
-  padding-left: 1em;
-  display: none; }
-  nav.primary > ul > li > ul > li {
-    float: left; }
-    nav.primary > ul > li > ul > li > a {
-      font-size: .75em;
-      line-height: 1.34;
-      padding: .33em 1em .33em; }
-nav.primary > ul > li:hover > a {
-  background: #13abe8;
-  color: #e9e9e9; }
-nav.primary > ul > li:hover > ul > li:hover > a {
-  color: #fff; }
-nav.primary > ul > li.active > a, nav.primary > ul > li.active > a:hover {
-  background: #555; }
-nav.primary > ul > li.active > ul {
+  margin-bottom: 0;
+  padding-left: 0;
+}
+nav ul:before, nav ul:after {
+  content: '';
+  display: table;
+}
+nav ul:after {
+  clear: both;
+}
+nav ul li {
   display: block;
-  /* MEDIA QUERY needs to turn this to none */
-  background: #555; }
+  margin-bottom: 0;
+}
+nav ul li a {
+  white-space: nowrap;
+  display: block;
+}
 
-header nav.secondary {
-  background: #555;
-  display: none; }
-  header nav.secondary ul li a {
-    color: #999;
-    font-size: .75em;
-    line-height: 2.67;
-    padding: 0 12px; }
-  header nav.secondary ul li:first-child a {
-    padding: 0 12px 0 16px; }
-  header nav.secondary ul li:hover a,
-  header nav.secondary ul li.active a {
-    color: #fff; }
-
-/* == aside secondary navigation == */
-aside nav.secondary > ul > li {
-  border-top: 1px solid #ddd; }
-  aside nav.secondary > ul > li > a {
-    padding: .5em 0; }
-    aside nav.secondary > ul > li > a:hover {
-      color: #444; }
-  aside nav.secondary > ul > li > ul > li {
-    border: none; }
-    aside nav.secondary > ul > li > ul > li > a {
-      color: #999;
-      font-size: .75em;
-      line-height: 1.34;
-      padding: .333em 0; }
-  aside nav.secondary > ul > li > ul > li:last-child > a {
-    padding: .333em 0 1em; }
-aside nav.secondary > ul > li:first-child {
-  border-top: none; }
-
-/* == utility navigation == */
+header nav ul {
+  margin-bottom: 1em;
+}
+header nav ul li {
+  padding-left: 1em;
+}
+header nav ul li a,
+header nav ul li a:visited {
+  color: #888888;
+}
+header nav ul li a:hover {
+  color: #fcfcfc;
+}
+header nav ul li ul li {
+  float: left;
+}
+header nav ul li ul li a {
+  font-size: .75em;
+  line-height: 1.34;
+  padding: .33em 1em .33em;
+}
+header nav.primary ul li.active {
+  background: #2a2a2a;
+}
+header nav.primary > ul > li > a {
+  color: #cccccc;
+  font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+header nav.primary > ul > li > a:hover {
+  color: #fcfcfc;
+}
+header nav.primary > ul > li.active > a {
+  color: #0096d2;
+}
 header nav.utility {
   display: none;
-  position: absolute;
-  right: 0;
-  text-align: right;
-  top: 1em; }
-  header nav.utility > ul {
-    position: relative; }
-    header nav.utility > ul > li {
-      float: left; }
-  header nav.utility a {
-    font-size: .75em;
-    line-height: 2;
-    padding: 0 .667em; }
+}
+header nav.utility ul li a {
+  font-size: .75em;
+  line-height: 2;
+  padding-left: .667em;
+  padding-right: .667em;
+}
+header nav.secondary {
+  display: none;
+}
+
+aside nav > ul li a {
+  padding-top: .5em;
+  padding-bottom: .5em;
+}
+aside nav > ul li a:hover {
+  color: #555555;
+}
+aside nav > ul li ul li a {
+  color: #888888;
+  font-size: .75em;
+  line-height: 1.34;
+  padding-top: .333em;
+  padding-bottom: .333em;
+}
+aside nav > ul li ul li:last-child a {
+  padding-top: .333em;
+  padding-bottom: 1em;
+}
+aside nav > ul > li {
+  border-top: 1px solid #ddd;
+}
+aside nav > ul > li:first-child {
+  border-top: none;
+}
 
 /* = Forms = */
 button,
 input,
 select,
 textarea {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 100%; }
-  html.lt-ie8 button, html.lt-ie8
-  input, html.lt-ie8
-  select, html.lt-ie8
-  textarea {
-    vertical-align: middle; }
-
-select {
-  margin: .5em 0; }
+  font-size: 100%;
+}
 
 .button,
 .checkboxes,
@@ -429,7 +503,8 @@ select {
 .submit,
 .text,
 .textarea {
-  margin-bottom: 1.5em; }
+  margin-bottom: 1.5em;
+}
 
 label {
   color: #333;
@@ -437,29 +512,20 @@ label {
   display: block;
   font-weight: bold;
   line-height: 2;
-  margin: 0; }
+}
 
 span.required {
-  color: #ac181b; }
+  color: #ac181b;
+}
 
 fieldset .help {
-  color: #999;
+  color: #888;
   display: block;
   font-size: .75em;
   line-height: 1.34;
   margin: 0;
-  padding: 0; }
-
-.radio,
-.checkbox {
-  font-weight: normal;
-  margin: 0 0 .5em;
-  padding: 0 0 0 .25em; }
-
-html.lt-ie8 input[type="checkbox"], html.lt-ie8
-input[type="radio"] {
-  height: 13px;
-  width: 13px; }
+  padding: 0;
+}
 
 input[type="text"],
 input[type="password"],
@@ -472,45 +538,53 @@ textarea {
   font-size: 1em;
   line-height: 2;
   margin: 0;
-  padding: 0 1%;
-  width: 98%; }
-  html.lt-ie9 input[type="text"], html.lt-ie9
-  input[type="password"], html.lt-ie9
-  textarea {
-    border: 1px solid #848484; }
+  padding-left: 1%;
+  padding-right: 1%;
+  width: 98%;
+}
 
-input[type="file"] {
-  color: #333;
-  display: block;
-  font-size: 1em;
-  line-height: 2;
-  margin: 0;
-  padding: 0;
-  width: 100%; }
+select {
+  margin-bottom: 0;
+}
+
+.multiple select {
+  padding-left: 5px;
+  padding-right: 10px;
+}
 
 textarea {
   height: 12em;
   overflow: auto;
-  resize: vertical; }
+  resize: vertical;
+}
+
+.radio,
+.checkbox {
+  font-weight: normal;
+}
 
 input[type="checkbox"],
 input[type="radio"] {
   -ms-box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
+
+input[type="file"] {
+  color: #333;
+  display: block;
+  font-size: 1em;
+  width: 100%;
+}
 
 button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   -webkit-appearance: button;
-  cursor: pointer; }
-  html.lt-ie8 button, html.lt-ie8
-  input[type="button"], html.lt-ie8
-  input[type="reset"], html.lt-ie8
-  input[type="submit"] {
-    overflow: visible; }
+  cursor: pointer;
+}
 
 button,
 input[type="button"],
@@ -522,271 +596,403 @@ a.button {
   border: none;
   color: #fff;
   display: inline-block;
-  font-weight: bold;
+  font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 600;
   line-height: 1;
-  margin: 0 .5em .5em 0;
+  margin-bottom: .5em;
+  margin-right: .5em;
   padding: .5em .5em;
-  text-align: center; }
-  button:hover,
-  input[type="button"]:hover,
-  input[type="reset"]:hover,
-  input[type="submit"]:hover,
-  a.button:hover {
-    background: #13ABE8;
-    cursor: pointer; }
-  button:focus,
-  input[type="button"]:focus,
-  input[type="reset"]:focus,
-  input[type="submit"]:focus,
-  a.button:focus {
-    background: #0084B8; }
+  text-align: center;
+}
+button:hover,
+input[type="button"]:hover,
+input[type="reset"]:hover,
+input[type="submit"]:hover,
+a.button:hover {
+  background: #13abe8;
+  cursor: pointer;
+}
+button:focus,
+input[type="button"]:focus,
+input[type="reset"]:focus,
+input[type="submit"]:focus,
+a.button:focus {
+  background: #0084b8;
+}
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
   border: 0;
-  padding: 0; }
+  padding: 0;
+}
 
 /* = Messaging = */
 .messaging {
   border-radius: 5px;
-  margin: 0 0 1.5em;
+  margin-bottom: 1.5em;
   padding: 1em 3.25em;
-  position: relative; }
-  .messaging:before {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QEQAh0Zl47LzAAAAuJJREFUWMPtmO9H3VEcx9/t5nK5ZNGMy7iJiBgxRkT2YESPNnEf7VHsUUSKnk00MSIuoz9gGqNEbItNjFhGbEYaEc0od5qItteenG87O31/nO+93x5s9eHwdb6f7+uc8zmfz+d8P0f6rwXoBHaAPeBu1vA1/sg+UMwKXOGsTGcBLgK7BnhoTANwDHQ0Cp80sM9Ai+mrmr7lRsAlM1uAp1Z/n2WevjjGlZh3M5KCjftp9dvPs0AuFRzolVTxWOBNScNpZz6bwoJTwX4kwoGKpJ4U8FZJE4lwExwzdez/aJhrujOflFQK+fi69Rzm3/lYUwIdJjiipApMW+4ZJv1RM58yM4iSvKTvpkXJkzOuCfQSLy8t3YEE3YenMzcjzSVsmO1qRQ/XbA1mMoafrAHzQM1Dd16SmoAvksoZny8/JF3TpVwcKUh6IOm5pF1JWG1H0jPzvpAGmpM0IqnmAKNazSS8vE9ufuMJddumpBtxiWm9TnDQ9iJSsuY8Pj6QdF/SeIzOR3cfypKOPeCv7GQa0/469qZTLP2xpIUEnX1JhWYD9zmQX0vaMLp3PByjtznkjIwDB8vdltSe8E1n8PDe0ySBHHjojgVn6CcPs2xYJrzqof81gC952lwe9g7krR3yHxKWGUAXPEyy6o7UJ+kk5oNxo9du3DFK70TS7bClDHsE0XaCzmicre5JOqoztzzy2Yyyyddp4f1pcnurKQJeSDp0QL98NrJe6TKrc004FCg0ZTBI0YR6j/n9XrIC7lL+0SuTbmDkPMAl6/Jh+fTHPwNwC7Dp/PivZAEuAKsOeBcoNQrOAYsOuAZ0ZzHrqgM+dmvQesETIQVWJQtw2H3XRBpAV0R/f0j5Xk0DHgpu3+wy2wSJW38uxt0SueAe4Mj2V+PHdpAEsg4UfMFtIQCArZAg2QLa0pgjD8x5lN3f6r5PBAZjavsj4Faj7lYG3oUEyWBWCSlvPCa7IAkZZOBc8vTFlt90PErGWW5fZgAAAABJRU5ErkJggg==);
-    background-position: 0 0;
-    background-repeat: no-repeat;
-    content: '';
-    display: block;
-    height: 23px;
-    left: 1em;
-    position: absolute;
-    top: 1em;
-    width: 23px; }
-  .messaging a {
-    color: inherit;
-    text-decoration: underline; }
-  .messaging.error {
-    background: #C44949;
-    color: #FCFCFC; }
-    .messaging.error:before {
-      background-position: 0 0; }
-  .messaging.success {
-    background: #40B36E;
-    color: #FCFCFC; }
-    .messaging.success:before {
-      background-position: 0 -46px; }
-  .messaging.info {
-    background: #CCCCCC;
-    color: #555555; }
-    .messaging.info:before {
-      background-position: 0 -23px; }
+  position: relative;
+}
+.messaging a {
+  text-decoration: underline;
+}
+.messaging:before {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA5FJREFUeNrsWG9klVEYv/fuirFc3ZSxLJsRq2vLZYlL2fpQSpG0qU8jSynNqJbbt8bWKEsfpsSITf+UEku1NEWWImaXWMVIaZQxxpj1PPmd6+k4O+e8995J3Ief+77vPe/vnPd5nvP8OeHFxcXQckl4Ocmjmfp6n3EbCE8JKwithCc+L0U8F3GDUEkoJwwSygpFfoiQEvdxQroQ5LzCXlzPEqZw3UGoyZf8FKGC8JGwjrCe0A/d9+VDzqSduB4lzOD6Nn53E7blSt4rDLcgnstrXn1JUPIUDOkS9uO2oOR9AfZKFyHmS84rTgYgjwvbWMml6wURo2vq5Gl4iS7l4trk30bXDE/U1cmXJjDQJP1wxxOW7d9EeGFaeZeFWK1uRvi7SS5J14wI12u2vPSMcITQQzjq65oRzHTVYbCYZnSXa8YVeQdmtEkD4RVC7zUP1+xVBv1Mv1UFTkIcQdeG/9scWiQ3lxZ/dtDAD9N/pdhYnHG2ajGHc+kblBicmeZ8Q24Jcuc3wgDhgCGYVWLiAYxLm0JHxLABRhDhYp5fH8OufIdJjeQ887Ar6VokQRiTITmiRbQGB8EvwsGlMg/i/kPYK0teZUu0Qt4T7hIuWsbUwmZZ8jZHLFeyA2H3jmPcaV59FDc+Cfk5Vp7EJK7ImIoacqSNWOn6E6HaVXYrtcx7qOOsuF/l8aWlijzjaUylQh/y74r8kafOQx76VjKqyB8QPniS+xify4upiKhc27UKVhdF2unwc+Y4n42KogY/bknAPVBJtcNTziBi/kXOcp3wk3BTbWGD19jkAuGyLeTeI2wUHUQQeelTn38htBBWEw7D4LPaGFMKSwdpuFhFQ4T9hJWcFgU2GbJQoywLo3mkyAy+rgwddhIZa7JYWvxj8i0jiXx5EvCUK3wz1jQe6Egk5Gjjh1GOPFaFfyHIYyCuEOcBg4Ug59hzHypR8hW9U17kXPLdgp6VcJe3CxPkRc4N2l5xP48QMZ7LGZcUThbHtGetsrnNlZwPHbq1Z+cQ3LxK6NoliBtRMuste4/veUsz+v9u7QQoAc+QJR9XDCd9j6GSYmWd2BAxsUlkvf4W4XbB2baQrJGlL2QnCvo5rbPgeL1nqVbFtPIZpDJdarRNMg1fnvaxvqwVWX/7LEcec1jxpK9r6QZlI21WdYe2SVqg61Cu5Crzb9dcrNWznjQaNGRYKW+O19D7UDGHFkx+CzAA6nHUdfvIb58AAAAASUVORK5CYII=);
+  background-position: 0 0;
+  background-repeat: no-repeat;
+  content: '';
+  display: block;
+  height: 23px;
+  left: 1em;
+  position: absolute;
+  top: 1em;
+  width: 23px;
+}
+
+.success {
+  background: #ecfae8;
+}
+.success:before {
+  background-position: 0 -46px;
+}
+
+.error {
+  background: #ffd7d7;
+}
+.error:before {
+  background-position: 0 0;
+}
+
+.info {
+  background: #bde5f8;
+}
+.info:before {
+  background-position: 0 -23px;
+}
 
 /* = Tables = */
-caption {
-  font-size: .75em;
-  line-height: 1.33em; }
-
 table {
   border-collapse: collapse;
   border-spacing: 0;
-  margin: 0 0 1.5em;
-  width: 100%; }
-  table thead th {
-    border-bottom: 1px solid #999; }
-  table td,
-  table th {
-    padding: .25em .5em;
-    text-align: left;
-    vertical-align: top; }
-  table th {
-    font-weight: bold; }
+  margin-bottom: 1.5em;
+  width: 100%;
+}
+table caption {
+  font-size: .75em;
+}
+table td,
+table th {
+  padding: .25em 8px;
+  text-align: left;
+  vertical-align: top;
+}
+table th {
+  font-weight: bold;
+}
+table thead th {
+  border-bottom: 1px solid #999;
+}
 
 /* = Section Specific = */
 /* = Page Specific = */
 /* = Media Queries = */
 @media only screen and (min-width: 640px) {
-  header nav.utility {
-    display: block; }
+  blockquote {
+    margin-left: 3em;
+    margin-right: 3em;
+  }
 
-  nav.primary,
-  header nav.secondary {
-    display: block; }
-    nav.primary > ul > li,
-    header nav.secondary > ul > li {
-      float: left;
-      position: relative;
-      white-space: nowrap; }
-      nav.primary > ul > li > a:hover,
-      header nav.secondary > ul > li > a:hover {
-        color: #ffffff; }
-      nav.primary > ul > li > ul,
-      header nav.secondary > ul > li > ul {
-        display: none;
-        left: 0;
-        overflow: hidden;
-        position: absolute;
-        width: 200px;
-        background: #13abe8;
-        margin: 0;
-        padding: 0; }
-        nav.primary > ul > li > ul > li,
-        header nav.secondary > ul > li > ul > li {
-          float: none;
-          min-width: 100%; }
-          nav.primary > ul > li > ul > li > a,
-          header nav.secondary > ul > li > ul > li > a {
-            padding: .6em 1.33em .6em;
-            font-size: .875em;
-            line-height: 2; }
-    nav.primary > ul > li:hover > a,
-    header nav.secondary > ul > li:hover > a {
-      border-top-left-radius: 6px;
-      border-top-right-radius: 6px; }
-    nav.primary > ul > li:hover > ul,
-    header nav.secondary > ul > li:hover > ul {
-      display: block;
-      z-index: 2;
-      border-bottom-left-radius: 6px;
-      border-bottom-right-radius: 6px; }
-    nav.primary > ul > li.active > a,
-    header nav.secondary > ul > li.active > a {
-      border-top-left-radius: 6px;
-      border-top-right-radius: 6px; }
-    nav.primary > ul > li.active > ul,
-    header nav.secondary > ul > li.active > ul {
-      display: none; } }
-html.lt-ie9 header nav.utility {
-  display: block; }
-html.lt-ie9 nav.primary,
-html.lt-ie9 header nav.secondary {
-  display: block; }
-  html.lt-ie9 nav.primary > ul > li,
-  html.lt-ie9 header nav.secondary > ul > li {
-    float: left;
+  header > .container {
     position: relative;
-    white-space: nowrap; }
-    html.lt-ie9 nav.primary > ul > li > a:hover,
-    html.lt-ie9 header nav.secondary > ul > li > a:hover {
-      color: #ffffff; }
-    html.lt-ie9 nav.primary > ul > li > ul,
-    html.lt-ie9 header nav.secondary > ul > li > ul {
-      display: none;
-      left: 0;
-      overflow: hidden;
-      position: absolute;
-      width: 200px;
-      background: #13abe8;
-      margin: 0;
-      padding: 0; }
-      html.lt-ie9 nav.primary > ul > li > ul > li,
-      html.lt-ie9 header nav.secondary > ul > li > ul > li {
-        float: none;
-        min-width: 100%; }
-        html.lt-ie9 nav.primary > ul > li > ul > li > a,
-        html.lt-ie9 header nav.secondary > ul > li > ul > li > a {
-          padding: .6em 1.33em .6em;
-          font-size: .875em;
-          line-height: 2; }
-  html.lt-ie9 nav.primary > ul > li:hover > a,
-  html.lt-ie9 header nav.secondary > ul > li:hover > a {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px; }
-  html.lt-ie9 nav.primary > ul > li:hover > ul,
-  html.lt-ie9 header nav.secondary > ul > li:hover > ul {
+  }
+  header nav {
+    position: relative;
+  }
+  header nav ul {
+    margin-bottom: 0;
+  }
+  header nav ul li {
+    padding-left: 0;
+    float: left;
+  }
+  header nav ul li ul li {
+    float: none;
+  }
+  header nav ul li ul li a {
+    padding-left: 0;
+    line-height: 2;
+  }
+  header nav > ul > li {
+    position: relative;
+  }
+  header nav > ul > li > a {
+    padding: .25em 16px;
+  }
+  header nav > ul > li .dropdown {
+    box-shadow: 0 3px 5px 0px #1a1a1a;
+    display: none;
+    position: absolute;
+    left: 0;
+    background: #2a2a2a;
+    z-index: 1;
+    padding-left: 16px;
+    padding-right: 16px;
+    min-width: 192px;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  header nav > ul > li:hover .dropdown {
     display: block;
-    z-index: 2;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px; }
-  html.lt-ie9 nav.primary > ul > li.active > a,
-  html.lt-ie9 header nav.secondary > ul > li.active > a {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px; }
-  html.lt-ie9 nav.primary > ul > li.active > ul,
-  html.lt-ie9 header nav.secondary > ul > li.active > ul {
-    display: none; }
+  }
+  header nav.primary ul li.active {
+    background: none;
+  }
+  header nav.primary ul li:hover a {
+    background: #2a2a2a;
+  }
+  header nav.secondary {
+    display: block;
+    background: #2a2a2a;
+  }
+  header nav.secondary ul li {
+    float: left;
+  }
+  header nav.secondary ul li a {
+    font-size: .75em;
+    padding: 0 12px;
+    line-height: 2.67;
+  }
+  header nav.secondary ul li:first-child a {
+    padding-left: 16px;
+  }
+  header nav.secondary ul li.active a {
+    color: #fcfcfc;
+  }
+  header nav.utility {
+    display: block;
+    position: absolute;
+    top: 1em;
+    right: 32px;
+  }
+}
+html.lt-ie9 blockquote {
+  margin-left: 3em;
+  margin-right: 3em;
+}
+html.lt-ie9 header > .container {
+  position: relative;
+}
+html.lt-ie9 header nav {
+  position: relative;
+}
+html.lt-ie9 header nav ul {
+  margin-bottom: 0;
+}
+html.lt-ie9 header nav ul li {
+  padding-left: 0;
+  float: left;
+}
+html.lt-ie9 header nav ul li ul li {
+  float: none;
+}
+html.lt-ie9 header nav ul li ul li a {
+  padding-left: 0;
+  line-height: 2;
+}
+html.lt-ie9 header nav > ul > li {
+  position: relative;
+}
+html.lt-ie9 header nav > ul > li > a {
+  padding: .25em 16px;
+}
+html.lt-ie9 header nav > ul > li .dropdown {
+  box-shadow: 0 3px 5px 0px #1a1a1a;
+  display: none;
+  position: absolute;
+  left: 0;
+  background: #2a2a2a;
+  z-index: 1;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-width: 192px;
+  -ms-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+html.lt-ie9 header nav > ul > li:hover .dropdown {
+  display: block;
+}
+html.lt-ie9 header nav.primary ul li.active {
+  background: none;
+}
+html.lt-ie9 header nav.primary ul li:hover a {
+  background: #2a2a2a;
+}
+html.lt-ie9 header nav.secondary {
+  display: block;
+  background: #2a2a2a;
+}
+html.lt-ie9 header nav.secondary ul li {
+  float: left;
+}
+html.lt-ie9 header nav.secondary ul li a {
+  font-size: .75em;
+  padding: 0 12px;
+  line-height: 2.67;
+}
+html.lt-ie9 header nav.secondary ul li:first-child a {
+  padding-left: 16px;
+}
+html.lt-ie9 header nav.secondary ul li.active a {
+  color: #fcfcfc;
+}
+html.lt-ie9 header nav.utility {
+  display: block;
+  position: absolute;
+  top: 1em;
+  right: 32px;
+}
 
 @media only screen and (min-width: 800px) {
-  .branding {
-    padding: 1.75em 0; }
-
-  aside.primary {
-    padding: 0 1em 0 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: 192px; }
+  .container {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1024px;
+    padding-left: 16px;
+    padding-right: 16px;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+  }
 
   .main {
-    margin-right: 192px;
-    padding: 0 32px 0 0; }
+    width: 76%;
+    float: left;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+  }
 
-  .mold {
-    margin: 0 auto;
-    max-width: 1024px;
-    padding: 0 16px;
-    position: relative; } }
-html.lt-ie9 .branding {
-  padding: 1.75em 0; }
-html.lt-ie9 aside.primary {
-  padding: 0 1em 0 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 192px; }
-html.lt-ie9 .main {
-  margin-right: 192px;
-  padding: 0 32px 0 0; }
-html.lt-ie9 .mold {
-  margin: 0 auto;
+  aside.primary {
+    width: 24%;
+    float: right;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+}
+html.lt-ie9 .container {
+  margin-left: auto;
+  margin-right: auto;
   max-width: 1024px;
-  padding: 0 16px;
-  position: relative; }
+  padding-left: 16px;
+  padding-right: 16px;
+  -ms-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+html.lt-ie9 .main {
+  width: 76%;
+  float: left;
+  -ms-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+html.lt-ie9 aside.primary {
+  width: 24%;
+  float: right;
+  -ms-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
 
-/* = IE Specific = */
-/* = Print Styles = */
+/* IE Specific */
+html.lt-ie8 .group,
+html.lt-ie8 .container {
+  zoom: 1;
+}
+html.lt-ie8 button,
+html.lt-ie8 input,
+html.lt-ie8 select,
+html.lt-ie8 textarea {
+  vertical-align: middle;
+}
+html.lt-ie8 button,
+html.lt-ie8 input[type="button"],
+html.lt-ie8 input[type="reset"],
+html.lt-ie8 input[type="submit"] {
+  overflow: visible;
+}
+html.lt-ie8 input[type="checkbox"],
+html.lt-ie8 input[type="radio"] {
+  height: 13px;
+  width: 13px;
+}
+
 @media print {
   * {
     background: transparent !important;
     box-shadow: none !important;
     color: #000 !important;
-    text-shadow: none !important; }
+    /* Black prints faster: h5bp.com/s */
+    text-shadow: none !important;
+  }
 
   a,
   a:visited {
-    text-decoration: underline; }
+    text-decoration: underline;
+  }
 
   a[href]:after {
-    content: " (" attr(href) ")"; }
+    content: " (" attr(href) ")";
+  }
 
   abbr[title]:after {
-    content: " (" attr(title) ")"; }
+    content: " (" attr(title) ")";
+  }
 
   a[href^="javascript:"]:after,
   a[href^="#"]:after {
-    content: ''; }
+    content: '';
+  }
 
   pre,
   blockquote {
     border: 1px solid #999;
-    page-break-inside: avoid; }
+    page-break-inside: avoid;
+  }
 
   thead {
-    display: table-header-group; }
+    display: table-header-group;
+  }
 
   tr,
   img {
-    page-break-inside: avoid; }
+    page-break-inside: avoid;
+  }
 
   @page {
-    margin: 0.5cm; }
+    margin: 0.5cm;
+}
 
   p,
   h2,
   h3 {
     orphans: 3;
-    widows: 3; }
+    widows: 3;
+  }
 
   h2,
   h3 {
-    page-break-after: avoid; } }
+    page-break-after: avoid;
+  }
+}

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1,8 +1,14 @@
 /* = Table of Contents =
 
+ * Colors
  * Web Fonts
  * Base
  * Mixins
+ * Grouping
+ * Layout
+ * Typography
+ * Navigation
+ * Forms
  * Messaging
  * Tables
  * Section Specific
@@ -12,7 +18,28 @@
  * Print Styles
  */
 
+/* = Colors = */
+$background: #fcfcfc;
+$text: #555;
+$selection: #fff6b5;
+
+$darkgray: #1a1a1a;
+$midgray: #2a2a2a;
+$lightgray: #ccc;
+$white: #fcfcfc;
+
+$textgray: #888;
+$textprimary: #f2006d;
+$textsecondary: #0096d2;
+$textsecondarylit: #13abe8;
+$textsecondaryfocused: #0084b8;
+
+$success: #ecfae8;
+$error: #ffd7d7;
+$info: #bde5f8;
+
 /* = Web Fonts = */
+@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600);
 
 
 /* = Base = */
@@ -44,9 +71,9 @@ img {
 }
 
 html {
-	background: #FCFCFC;
-	color: #555555;
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	background: $background;
+	color: $text;
+	font-family:  Arial, Helvetica, sans-serif;
 	-ms-text-size-adjust: 100%;
 	-webkit-text-size-adjust: 100%;
 }
@@ -58,12 +85,12 @@ body {
 }
 
 ::-moz-selection {
-	background: #FFF6B5;
+	background: $selection;
 	text-shadow: none;
 }
 
 ::selection {
-	background: #FFF6B5;
+	background: $selection;
 	text-shadow: none;
 }
 
@@ -79,15 +106,6 @@ body {
 	&:after {
 		clear: both;
 	}
-
-	html.lt-ie8 & {
-		zoom: 1;
-	}
-}
-
-.mold,
-.group {
-	@include grouping;
 }
 
 @mixin columns {
@@ -95,13 +113,10 @@ body {
 	table-layout: fixed;
 	width: 100%;
 
-	> div {
+	> * {
 		display: table-cell;
+		width: 100%;
 	}
-}
-
-.columns {
-	@include columns;
 }
 
 @mixin for-tablets {
@@ -124,76 +139,91 @@ body {
 	}
 }
 
+/* = Grouping = */
+.group,
+.container {
+	@include grouping;
+}
+
+.columns {
+	@include columns;
+}
+
 
 /* = Layout = */
 header.primary,
 .torso,
 footer.primary {
 	position: relative;
-	margin: 0 0 2.5em;
+	margin-bottom: 2.5em;
 }
 
 header.primary {
-	background: #0096d2;
-
-	a {
-		color: #d8e7ed;
-
-		&:hover {
-			color: #fcfcfc;
-		}
-	}
+	background: $darkgray;
 
 	.branding {
 		padding: 1.5em 16px;
 
 		h1 {
 			margin: 0;
+
+			a {
+				color: $white;
+			}
 		}
 	}
 }
 
+.torso {
+	.main,
+	aside.primary {
+		padding-left: 16px;
+		padding-right: 16px;
 
-.main,
-aside.primary {
-	padding: 0 16px;
-}
+		article {
+			.meta {
+				color: $textgray;
+				font-size: .875em;
+				margin-top: -.5em;
+				margin-bottom: 1em;
+			}
+		}
+	}
 
-.main {
-	section,
-	article {
-		margin: 0 0 3em;
+	.main {
+		article,
+		section {
+			margin-bottom: 3em;
+		}
 
-		.meta {
-			color: #aaa;
+		aside {
+			background: #eee;
+			border-radius: 5px;
+			color: #888;
+			float: right;
 			font-size: .875em;
-			line-height: 1.71;
-			margin: -1.71em 0 .57em;
+			line-height: 1.43em;
+			margin-bottom: 1.333em;
+			margin-left: 1.333em;
+			padding: 1.333em;
+			text-shadow: 0px 1px 0px #fff;
+			width: 33.33%;
 		}
 	}
 
-	aside {
-		background: #eee;
-		border-radius: 5px;
-		color: #888;
-		float: right;
-		font-size: .875em;
-		line-height: 1.43em;
-		margin: 0 0 1.333em 1.333em;
-		padding: 1.333em;
-		width: 33.33%;
+	aside.primary {
+		article,
+		section {
+			margin-bottom: 1.5em;
+		}
 	}
-}
-
-
-aside section {
-	margin: 0 0 1.5em;
 }
 
 footer.primary {
-	color: #999;
+	color: $textgray;
 	font-size: 0.875em;
-	text-align: center;
+	padding-left: 16px;
+	padding-right: 16px;
 }
 
 
@@ -204,11 +234,8 @@ h3,
 h4,
 h5,
 h6 {
-	&,
-	& a {
-		font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
-		font-weight: normal;
-	}
+	font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-weight: normal;
 
 	&:first-child {
 		margin-top: 0;
@@ -216,55 +243,59 @@ h6 {
 }
 
 h1 {
-	color: #f2006d;
+	color: $textprimary;
 	font-size: 3em;
-	line-height: 1;
-	margin: 1.67em 0 .5em;
+	line-height: 1.2;
+	margin-top: 1.67em;
+	margin-bottom: .5em;
 }
 
 h2 {
 	font-size: 2.5em;
-	line-height: 1;
-	margin: 1.2em 0 .6em;
+	line-height: 1.2;
+	margin-top: 1.2em;
+	margin-bottom: .4em;
 }
 	h1 + h2 {
-		margin-top: -.4em;
+		margin-top: -.2em;
 	}
 
 h3 {
 	font-size: 1.5em;
-	line-height: 1.67;
-	margin: 2em 0 1em;
+	line-height: 1.3;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
 	h2 + h3 {
-		margin-top: -1em;
+		margin-top: -.4em;
+		margin-bottom: .2em;
 	}
 
 h4 {
 	font-size: 1.25em;
-	line-height: 1.2;
-	margin: 1.6em 0 .8em;
+	line-height: 1.4;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
 	h3 + h4 {
-		margin-top: -1.2em;
+		margin-top: -.3em;
 	}
 
 h5 {
 	font-size: 1em;
-	line-height: 1.5;
-	margin: 0 0 .5em;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
-	h4 + h5,
-	h4 + h6 {
-		margin-top: -1em;
+	h4 + h5 {
+		margin-top: -.3em;
 	}
 h6 {
-	font-size: .75em;
-	line-height: 1.33;
-	margin: 0 0 .67em;
+	font-size: .9em;
+	margin-top: 1.8em;
+	margin-bottom: .4em;
 }
 	h5 + h6 {
-		margin-top: -.67em;
+		margin-top: -.2em;
 	}
 
 abbr[title] {
@@ -274,7 +305,6 @@ abbr[title] {
 b,
 strong {
 	font-weight: bold;
-	line-height: 22px; /*hack for mac/linux*/
 }
 
 i,
@@ -284,43 +314,54 @@ em {
 
 blockquote,
 pre {
-	color: #666;
-	clear: both;
-	margin: 0 0 1.5em;
-	padding: 0 1em;
+	@include grouping;
+	color: $textgray;
+	margin-bottom: 1.5em;
 }
 
 blockquote {
 	font-style: italic;
-	border-left: 1px solid #ccc;
+	border-left: 1px solid $lightgray;
+	margin-left: 2em;
+	margin-right: 1em;
+	padding-left: 1em;
+	padding-right: 1em;
 }
 
-.main .intro {
-	border-bottom: 1px solid #ddd;
-	margin: 0 0 2.5em;
-	padding: 0 0 1.5em;
+.main {
+	.intro {
+		border-bottom: 1px solid $lightgray;
+		margin-bottom: 2.5em;
+		padding-bottom: 1.5em;
 
-	p {
+		p {
+			color: #888;
+			font-size: 1.25em;
+			line-height: 1.6;
+			margin-bottom: .8em;
+		}
+	}
+
+	.highlight {
+		background: #e9e9e9;
+		border-radius: 5px;
 		color: #888;
-		font-size: 1.25em;
-		line-height: 1.6;
-		margin: 0 0 .8em;
+		font-size: 1.5em;
+		line-height: 1.34;
+		margin-bottom: 1em;
+		padding: .67em;
+		text-shadow: 0px 1px 0px #fff;
+
+		p {
+			margin-bottom: 0;
+		}
 	}
 }
 
-.highlight {
-	background: #e9e9e9;
-	border-radius: 5px;
-	color: #888888;
-	font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-size: 1.5em;
-	line-height: 1.34;
-	margin: 0 0 1em;
-	padding: .67em;
-
-	p {
-		margin: 0;
-	}
+pre,
+code {
+	font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace;
+	font-size: .9em;
 }
 
 pre {
@@ -329,17 +370,13 @@ pre {
 	word-wrap: break-word;
 }
 
-pre,
-code {
-	font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace;
-}
 
 p {
-	margin: 0 0 1.5em;
+	margin-bottom: 1.5em;
 }
 
 address {
-	margin: 0 0 1.5em;
+	margin-bottom: 1.5em;
 }
 
 hr {
@@ -347,21 +384,21 @@ hr {
 	border-top: 1px solid #999;
 	display: block;
 	height: 0;
-	margin: 1em auto 3em;
+	margin: 2em auto 3em;
 	width: 75%;
 }
 
 a {
-	color: #0096d2;
+	color: $textsecondary;
 	text-decoration: none;
 
 	&:visited {
-		color: #0096d2;
+		color: $textsecondary
 	}
 
 	&:hover,
 	&:active {
-		color: #444;
+		color: $textgray;
 		outline: 0;
 	}
 
@@ -371,45 +408,45 @@ a {
 }
 
 ol,
-ul {
-	margin: 0 0 1.5em;
-	padding: 0 0 0 2em;
-}
-
-li,
-dt,
-dd {
-	margin: 0 0 .5em;
-}
-
-ul {
-	list-style: square;
-}
-
+ul,
 dl {
-	margin: 0 0 1.5em;
+	margin-bottom: 1.5em;
+}
+
+ol,
+ul {
+	padding-left: 2em;
+
+	li,
+	dt,
+	dd {
+		margin-bottom: .5em;
+	}
+}
+
+ul {
+	list-style: disc;
 }
 
 dt {
 	font-weight: bold;
-	padding: 0 0 0 .5em;
+	padding-left: .5em;
 }
 
 dd {
-	padding: 0 0 0 2em;
+	padding-left: 2em;
 }
 
-mark {
-	background: #FFF6B5;
+sup,
+sub {
+	font-size: 80%;
 }
 
 sup {
-	font-size: 80%;
 	vertical-align: top;
 }
 
 sub {
-	font-size: 80%;
 	vertical-align: bottom;
 }
 
@@ -420,182 +457,148 @@ nav {
 		@include grouping;
 
 		list-style: none;
-		margin: 0;
-		padding: 0;
+		margin-bottom: 0;
+		padding-left: 0;
 
 		li {
-			margin: 0;
 			display: block;
-			white-space: nowrap;
+			margin-bottom: 0;
 
 			a {
+				white-space: nowrap;
 				display: block;
 			}
 		}
 	}
 }
 
+header {
+	nav {
+		ul {
+			margin-bottom: 1em;
 
-/* == top primary navigation == */
-nav.primary {
-	> ul {
-		> li {
-			> a {
-				color: #e9e9e9;
-				padding: .25em 16px;
-			}
-			> ul {
-				margin-bottom: 1em;
+			li {
 				padding-left: 1em;
-				display: none;
-				> li {
-					float: left;
-					> a {
-						font-size: .75em;
-						line-height: 1.34;
-						padding: .33em 1em .33em;
+
+				a,
+				a:visited {
+					color: $textgray;
+				}
+				
+				a:hover {
+					color: $white;
+				}
+
+				ul {
+					li {
+						float: left;
+
+						a {
+							font-size: .75em;
+							line-height: 1.34;
+							padding: .33em 1em .33em;
+						}
 					}
 				}
 			}
 		}
-		> li:hover {
-			> a {
-				background: #13abe8;
-				color: #e9e9e9;
+	}
+
+	nav.primary {
+		ul {
+			li.active {
+				background: $midgray;
 			}
-			> ul {
-				> li:hover {
-					> a {
-						color: #fff;
+		}
+
+		> ul {
+			> li {
+				> a {
+					color: $lightgray;
+					font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+				}
+				> a:hover {
+					color: $white;
+				}
+			}
+			> li.active {
+				> a {
+					color: $textsecondary;
+				}
+			}
+		}
+	}
+
+	nav.utility {
+		display: none;
+		ul {
+			li {
+				a {
+					font-size: .75em;
+					line-height: 2;
+					padding-left: .667em;
+					padding-right: .667em;
+				}
+			}
+		}
+	}
+
+	nav.secondary {
+		display: none;
+	}
+}
+
+aside {
+	nav {
+		> ul {
+			li {
+				a {
+					padding-top: .5em;
+					padding-bottom: .5em;
+				}
+
+				a:hover {
+					color: $text;
+				}
+
+
+				ul {
+					li {
+						a {
+							color: $textgray;
+							font-size: .75em;
+							line-height: 1.34;
+							padding-top: .333em;
+							padding-bottom: .333em;
+						}
+					}
+
+					li:last-child {
+						a {
+							padding-top: .333em;
+							padding-bottom: 1em;
+						}
 					}
 				}
 			}
-		}
-		> li.active {
-			> a {
-				&,
-				&:hover {
-					background: #555;
-				}
+
+			> li {
+				border-top: 1px solid #ddd;
 			}
-			> ul {
-				display: block; /* MEDIA QUERY needs to turn this to none */
-				background: #555;
+
+			> li:first-child {
+				border-top: none;
 			}
 		}
 	}
 }
-
-
-header nav.secondary {
-	background: #555;
-	display: none;
-
-	ul {
-		li {
-			a {
-				color: #999;
-				font-size: .75em;
-				line-height: 2.67;
-				padding: 0 12px;
-			}
-		}
-
-		li:first-child {
-			a {
-				padding: 0 12px 0 16px;
-			}
-		}
-
-		li:hover,
-		li.active {
-			a {
-				color: #fff;
-			}
-		}
-	}
-}
-
-
-/* == aside secondary navigation == */
-aside nav.secondary {
-	> ul {
-		> li {
-			border-top: 1px solid #ddd;
-
-			> a {
-				padding: .5em 0;
-
-				&:hover {
-					color: #444;
-				}
-			}
-
-			> ul {
-				> li {
-					border: none;
-
-					> a {
-						color: #999;
-						font-size: .75em;
-						line-height: 1.34;
-						padding: .333em 0;
-					}
-				}
-
-				> li:last-child {
-					> a {
-						padding: .333em 0 1em;
-					}
-				}
-			}
-		}
-
-		> li:first-child {
-			border-top: none;
-		}
-	}
-}
-
-/* == utility navigation == */
-header nav.utility {
-	display: none;
-	position: absolute;
-	right: 0;
-	text-align: right;
-	top: 1em;
-
-	> ul {
-		position: relative;
-
-		> li {
-			float: left;
-		}
-	}
-
-	a {
-		font-size: .75em;
-		line-height: 2;
-		padding: 0 .667em;
-	}
-}
-
 
 /* = Forms = */
 button,
 input,
 select,
 textarea {
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 100%;
-
-	html.lt-ie8 & {
-		vertical-align: middle;
-	}
-}
-
-select {
-	margin: .5em 0;
 }
 
 .button,
@@ -617,7 +620,6 @@ label {
 	display: block;
 	font-weight: bold;
 	line-height: 2;
-	margin: 0;
 }
 
 span.required {
@@ -625,26 +627,12 @@ span.required {
 }
 
 fieldset .help {
-	color: #999;
+	color: #888;
 	display: block;
 	font-size: .75em;
 	line-height: 1.34;
 	margin: 0;
 	padding: 0;
-}
-
-.radio,
-.checkbox {
-	font-weight: normal;
-	margin: 0 0 .5em;
-	padding: 0 0 0 .25em;
-}
-input[type="checkbox"],
-input[type="radio"] {
-	html.lt-ie8 & {
-		height: 13px;
-		width: 13px;
-	}
 }
 
 input[type="text"],
@@ -658,28 +646,28 @@ textarea {
 	font-size: 1em;
 	line-height: 2;
 	margin: 0;
-	padding: 0 1%;
+	padding-left: 1%;
+	padding-right: 1%;
 	width: 98%;
-
-	html.lt-ie9 & {
-		border: 1px solid #848484;
-	}
 }
 
-input[type="file"] {
-	color: #333;
-	display: block;
-	font-size: 1em;
-	line-height: 2;
-	margin: 0;
-	padding: 0;
-	width: 100%;
+select {
+	margin-bottom: 0;
+}
+.multiple select {
+	padding-left: 5px;
+	padding-right: 10px;
 }
 
 textarea {
 	height: 12em;
 	overflow: auto;
 	resize: vertical;
+}
+
+.radio,
+.checkbox {
+	font-weight: normal;
 }
 
 input[type="checkbox"],
@@ -690,16 +678,19 @@ input[type="radio"] {
 	box-sizing: border-box;
 }
 
+input[type="file"] {
+	color: #333;
+	display: block;
+	font-size: 1em;
+	width: 100%;
+}
+
 button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
 	-webkit-appearance: button;
 	cursor: pointer;
-
-	html.lt-ie8 & {
-		overflow: visible;
-	}
 }
 
 button,
@@ -712,19 +703,21 @@ a.button {
 	border: none;
 	color: #fff;
 	display: inline-block;
-	font-weight: bold;
+	font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-weight: 600;
 	line-height: 1;
-	margin: 0 .5em .5em 0;
+	margin-bottom: .5em;
+	margin-right: .5em;
 	padding: .5em .5em;
 	text-align: center;
 
 	&:hover {
-		background: #13ABE8;
+		background: $textsecondarylit;
 		cursor: pointer;
 	}
 
 	&:focus {
-		background: #0084B8;
+		background: $textsecondaryfocused;
 	}
 }
 
@@ -734,16 +727,20 @@ input::-moz-focus-inner {
 	padding: 0;
 }
 
-
 /* = Messaging = */
+
 .messaging {
 	border-radius: 5px;
-	margin: 0 0 1.5em;
+	margin-bottom: 1.5em;
 	padding: 1em 3.25em;
 	position: relative;
+	
+	a {
+		text-decoration: underline;
+	}
 
 	&:before {
-		background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QEQAh0Zl47LzAAAAuJJREFUWMPtmO9H3VEcx9/t5nK5ZNGMy7iJiBgxRkT2YESPNnEf7VHsUUSKnk00MSIuoz9gGqNEbItNjFhGbEYaEc0od5qItteenG87O31/nO+93x5s9eHwdb6f7+uc8zmfz+d8P0f6rwXoBHaAPeBu1vA1/sg+UMwKXOGsTGcBLgK7BnhoTANwDHQ0Cp80sM9Ai+mrmr7lRsAlM1uAp1Z/n2WevjjGlZh3M5KCjftp9dvPs0AuFRzolVTxWOBNScNpZz6bwoJTwX4kwoGKpJ4U8FZJE4lwExwzdez/aJhrujOflFQK+fi69Rzm3/lYUwIdJjiipApMW+4ZJv1RM58yM4iSvKTvpkXJkzOuCfQSLy8t3YEE3YenMzcjzSVsmO1qRQ/XbA1mMoafrAHzQM1Dd16SmoAvksoZny8/JF3TpVwcKUh6IOm5pF1JWG1H0jPzvpAGmpM0IqnmAKNazSS8vE9ufuMJddumpBtxiWm9TnDQ9iJSsuY8Pj6QdF/SeIzOR3cfypKOPeCv7GQa0/469qZTLP2xpIUEnX1JhWYD9zmQX0vaMLp3PByjtznkjIwDB8vdltSe8E1n8PDe0ySBHHjojgVn6CcPs2xYJrzqof81gC952lwe9g7krR3yHxKWGUAXPEyy6o7UJ+kk5oNxo9du3DFK70TS7bClDHsE0XaCzmicre5JOqoztzzy2Yyyyddp4f1pcnurKQJeSDp0QL98NrJe6TKrc004FCg0ZTBI0YR6j/n9XrIC7lL+0SuTbmDkPMAl6/Jh+fTHPwNwC7Dp/PivZAEuAKsOeBcoNQrOAYsOuAZ0ZzHrqgM+dmvQesETIQVWJQtw2H3XRBpAV0R/f0j5Xk0DHgpu3+wy2wSJW38uxt0SueAe4Mj2V+PHdpAEsg4UfMFtIQCArZAg2QLa0pgjD8x5lN3f6r5PBAZjavsj4Faj7lYG3oUEyWBWCSlvPCa7IAkZZOBc8vTFlt90PErGWW5fZgAAAABJRU5ErkJggg==);
+		background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA5FJREFUeNrsWG9klVEYv/fuirFc3ZSxLJsRq2vLZYlL2fpQSpG0qU8jSynNqJbbt8bWKEsfpsSITf+UEku1NEWWImaXWMVIaZQxxpj1PPmd6+k4O+e8995J3Ief+77vPe/vnPd5nvP8OeHFxcXQckl4Ocmjmfp6n3EbCE8JKwithCc+L0U8F3GDUEkoJwwSygpFfoiQEvdxQroQ5LzCXlzPEqZw3UGoyZf8FKGC8JGwjrCe0A/d9+VDzqSduB4lzOD6Nn53E7blSt4rDLcgnstrXn1JUPIUDOkS9uO2oOR9AfZKFyHmS84rTgYgjwvbWMml6wURo2vq5Gl4iS7l4trk30bXDE/U1cmXJjDQJP1wxxOW7d9EeGFaeZeFWK1uRvi7SS5J14wI12u2vPSMcITQQzjq65oRzHTVYbCYZnSXa8YVeQdmtEkD4RVC7zUP1+xVBv1Mv1UFTkIcQdeG/9scWiQ3lxZ/dtDAD9N/pdhYnHG2ajGHc+kblBicmeZ8Q24Jcuc3wgDhgCGYVWLiAYxLm0JHxLABRhDhYp5fH8OufIdJjeQ887Ar6VokQRiTITmiRbQGB8EvwsGlMg/i/kPYK0teZUu0Qt4T7hIuWsbUwmZZ8jZHLFeyA2H3jmPcaV59FDc+Cfk5Vp7EJK7ImIoacqSNWOn6E6HaVXYrtcx7qOOsuF/l8aWlijzjaUylQh/y74r8kafOQx76VjKqyB8QPniS+xify4upiKhc27UKVhdF2unwc+Y4n42KogY/bknAPVBJtcNTziBi/kXOcp3wk3BTbWGD19jkAuGyLeTeI2wUHUQQeelTn38htBBWEw7D4LPaGFMKSwdpuFhFQ4T9hJWcFgU2GbJQoywLo3mkyAy+rgwddhIZa7JYWvxj8i0jiXx5EvCUK3wz1jQe6Egk5Gjjh1GOPFaFfyHIYyCuEOcBg4Ug59hzHypR8hW9U17kXPLdgp6VcJe3CxPkRc4N2l5xP48QMZ7LGZcUThbHtGetsrnNlZwPHbq1Z+cQ3LxK6NoliBtRMuste4/veUsz+v9u7QQoAc+QJR9XDCd9j6GSYmWd2BAxsUlkvf4W4XbB2baQrJGlL2QnCvo5rbPgeL1nqVbFtPIZpDJdarRNMg1fnvaxvqwVWX/7LEcec1jxpK9r6QZlI21WdYe2SVqg61Cu5Crzb9dcrNWznjQaNGRYKW+O19D7UDGHFkx+CzAA6nHUdfvIb58AAAAASUVORK5CYII=);
 		background-position: 0 0;
 		background-repeat: no-repeat;
 		content:'';
@@ -754,68 +751,58 @@ input::-moz-focus-inner {
 		top: 1em;
 		width: 23px;
 	}
+}
 
-	a {
-		color: inherit;
-		text-decoration: underline;
-	}
+.success {
+	background: $success;
 
-	&.error {
-		background: #C44949;
-		color: #FCFCFC;
-
-		&:before {
-			background-position: 0 0;
-		}
-	}
-
-	&.success {
-		background: #40B36E;
-		color: #FCFCFC;
-
-		&:before {
-			background-position: 0 -46px;
-		}
-	}
-
-	&.info {
-		background: #CCCCCC;
-		color: #555555;
-
-		&:before {
-			background-position: 0 -23px;
-		}
+	&:before {
+		background-position: 0 -46px;
 	}
 }
 
+.error {
+	background: $error;
+
+	&:before {
+		background-position: 0 0;
+	}
+}
+
+.info {
+	background: $info;
+
+	&:before {
+		background-position: 0 -23px;
+	}
+}
 
 /* = Tables = */
-caption {
-	font-size: .75em;
-	line-height: 1.33em;
-}
-
 table {
 	border-collapse: collapse;
 	border-spacing: 0;
-	margin: 0 0 1.5em;
+	margin-bottom: 1.5em;
 	width: 100%;
 
-	thead {
-		th {
-			border-bottom: 1px solid #999;
-		}
+	caption {
+		font-size: .75em;
 	}
 
 	td,
 	th {
-		padding: .25em .5em;
+		padding: .25em 8px;
 		text-align: left;
 		vertical-align: top;
 	}
 
 	th {
 		font-weight: bold;
+	}
+
+	thead {
+		th {
+			border-bottom: 1px solid #999;
+		}
 	}
 }
 
@@ -826,109 +813,190 @@ table {
 
 
 /* = Media Queries = */
-
 @include for-tablets {
-	header nav.utility {
-		display: block;
+
+	blockquote {
+		margin-left: 3em;
+		margin-right: 3em;
 	}
 
-	nav.primary,
-	header nav.secondary {
-		display: block;
+	header {
+		> .container {
+			position: relative;
+		}
 
-		> ul {
-			> li {
-				float: left;
-				position: relative;
-				white-space: nowrap;
+		nav {
+			position: relative;
 
-				> a:hover {
-					color: #ffffff;
-				}
+			ul {
+				margin-bottom: 0;
 
-				> ul {
-					display: none;
-					left: 0;
-					overflow: hidden;
-					position: absolute;
-					width: 200px;
-					background: #13abe8;
-					margin: 0;
-					padding: 0;
+				li {
+					padding-left: 0;
+					float: left;
 
-					> li {
-						float: none;
-						min-width: 100%;
-
-						> a {
-							padding: .6em 1.33em .6em;
-							font-size: .875em;
-							line-height: 2;
+					ul {
+						li {
+							float: none;
+							a {
+								padding-left: 0;
+								line-height: 2;
+							}
 						}
 					}
 				}
 			}
-			> li:hover {
-				> a {
-					border-top-left-radius: 6px;
-					border-top-right-radius: 6px;
+
+			> ul {
+				> li {
+					position: relative;
+
+					> a {
+						padding: .25em 16px;
+					}
+
+					.dropdown {
+						box-shadow: 0 3px 5px 0px $darkgray;
+						display: none;
+						position: absolute;
+						left: 0;
+						background: $midgray;
+						z-index: 1;
+						padding-left: 16px;
+						padding-right: 16px;
+						min-width: 192px;
+						-ms-box-sizing: border-box;
+						-moz-box-sizing: border-box;
+						-webkit-box-sizing: border-box;
+						box-sizing: border-box;
+					}
 				}
-				> ul {
-					display: block;
-					z-index: 2;
-					border-bottom-left-radius: 6px;
-					border-bottom-right-radius: 6px;
+				> li:hover {
+					.dropdown {
+						display: block;
+					}
 				}
 			}
-			> li.active {
-				> a {
-					border-top-left-radius: 6px;
-					border-top-right-radius: 6px;
+		}
+
+		nav.primary {
+			ul {
+				li.active {
+					background: none;
 				}
-				> ul {
-					display: none;
+
+				li:hover {
+					a {
+						background: $midgray;
+					}
 				}
 			}
+		}
+
+		nav.secondary {
+			display: block;
+			background: $midgray;
+
+			ul {
+				li {
+					float: left;
+
+					a {
+						font-size: .75em;
+						padding: 0 12px;
+						line-height: 2.67;
+					}
+				}
+
+				li:first-child {
+					a {
+						padding-left: 16px;
+					}
+				}
+
+				li.active {
+					a {
+						color: $white;
+					}
+				}
+			}
+		}
+
+		nav.utility {
+			display: block;
+			position: absolute;
+			top: 1em;
+			right: 32px;
 		}
 	}
 }
 
 @include for-desktops {
-	.branding {
-		padding: 1.75em 0;
+
+	.container {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 1024px;
+		padding-left: 16px;
+		padding-right: 16px;
+		-ms-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+	}
+	
+	.main {
+		width: 76%;
+		float: left;
+		-ms-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
 	}
 
 	aside.primary {
-		padding: 0 1em 0 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-		width: 192px;
-	}
-
-	.main {
-		margin-right: 192px;
-		padding: 0 32px 0 0;
-	}
-
-	.mold {
-		margin: 0 auto;
-		max-width: 1024px;
-		padding: 0 16px;
-		position: relative;
+		width: 24%;
+		float: right;
+		-ms-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
 	}
 }
 
+/* IE Specific */
+html.lt-ie8 {
+	.group,
+	.container {
+		zoom: 1;
+	}
 
-/* = IE Specific = */
+	button,
+	input,
+	select,
+	textarea {
+		vertical-align: middle;
+	}
 
+	button,
+	input[type="button"],
+	input[type="reset"],
+	input[type="submit"] {
+		overflow: visible;
+	}
 
-/* = Print Styles = */
+	input[type="checkbox"],
+	input[type="radio"] {
+		height: 13px;
+		width: 13px;
+	}
+}
+
 @media print {
 	* {
 		background: transparent !important;
 		box-shadow: none !important;
-		color: #000 !important;
+		color: #000 !important; /* Black prints faster: h5bp.com/s */
 		text-shadow: none !important;
 	}
 

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1,0 +1,983 @@
+/* = Table of Contents =
+
+ * Web Fonts
+ * Base
+ * Mixins
+ * Messaging
+ * Tables
+ * Section Specific
+ * Page Specific
+ * Media Queries
+ * Internet Explorer
+ * Print Styles
+ */
+
+/* = Web Fonts = */
+
+
+/* = Base = */
+a, abbr, address, article, aside, audio, b, blockquote, body, canvas, cite,
+code, dd, div, dl, dt, em, fieldset, footer, form, h1, h2, h3, h4, h5, h6,
+header, html, i, iframe, img, label, li, nav, object, ol, p, pre, section,
+span, strong, sub, sup, table, tbody, td, tfoot, th, thead, tr, ul, video {
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	margin: 0;
+	outline: 0;
+	padding: 0;
+	vertical-align: baseline;
+}
+
+article, aside, footer, header, nav, section {
+	display: block;
+}
+
+audio, canvas, video {
+	display: inline-block;
+}
+
+img {
+	-ms-interpolation-mode: bicubic;
+	max-width: 100%;
+	vertical-align: middle;
+}
+
+html {
+	background: #FCFCFC;
+	color: #555555;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	-ms-text-size-adjust: 100%;
+	-webkit-text-size-adjust: 100%;
+}
+
+body {
+	font-size: 16px;
+	line-height: 1.5;
+	min-width: 310px;
+}
+
+::-moz-selection {
+	background: #FFF6B5;
+	text-shadow: none;
+}
+
+::selection {
+	background: #FFF6B5;
+	text-shadow: none;
+}
+
+
+/* = Mixins = */
+@mixin grouping {
+	&:before,
+	&:after {
+		content: '';
+		display: table;
+	}
+
+	&:after {
+		clear: both;
+	}
+
+	html.lt-ie8 & {
+		zoom: 1;
+	}
+}
+
+.mold,
+.group {
+	@include grouping;
+}
+
+@mixin columns {
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+
+	> div {
+		display: table-cell;
+	}
+}
+
+.columns {
+	@include columns;
+}
+
+@mixin for-tablets {
+	@media only screen and (min-width: 640px) {
+		@content;
+	}
+
+	html.lt-ie9 {
+		@content;
+	}
+}
+
+@mixin for-desktops {
+	@media only screen and (min-width: 800px) {
+		@content;
+	}
+
+	html.lt-ie9 {
+		@content;
+	}
+}
+
+
+/* = Layout = */
+header.primary,
+.torso,
+footer.primary {
+	position: relative;
+	margin: 0 0 2.5em;
+}
+
+header.primary {
+	background: #0096d2;
+
+	a {
+		color: #d8e7ed;
+
+		&:hover {
+			color: #fcfcfc;
+		}
+	}
+
+	.branding {
+		padding: 1.5em 16px;
+
+		h1 {
+			margin: 0;
+		}
+	}
+}
+
+
+.main,
+aside.primary {
+	padding: 0 16px;
+}
+
+.main {
+	section,
+	article {
+		margin: 0 0 3em;
+
+		.meta {
+			color: #aaa;
+			font-size: .875em;
+			line-height: 1.71;
+			margin: -1.71em 0 .57em;
+		}
+	}
+
+	aside {
+		background: #eee;
+		border-radius: 5px;
+		color: #888;
+		float: right;
+		font-size: .875em;
+		line-height: 1.43em;
+		margin: 0 0 1.333em 1.333em;
+		padding: 1.333em;
+		width: 33.33%;
+	}
+}
+
+
+aside section {
+	margin: 0 0 1.5em;
+}
+
+footer.primary {
+	color: #999;
+	font-size: 0.875em;
+	text-align: center;
+}
+
+
+/* = Typography = */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	&,
+	& a {
+		font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-weight: normal;
+	}
+
+	&:first-child {
+		margin-top: 0;
+	}
+}
+
+h1 {
+	color: #f2006d;
+	font-size: 3em;
+	line-height: 1;
+	margin: 1.67em 0 .5em;
+}
+
+h2 {
+	font-size: 2.5em;
+	line-height: 1;
+	margin: 1.2em 0 .6em;
+}
+	h1 + h2 {
+		margin-top: -.4em;
+	}
+
+h3 {
+	font-size: 1.5em;
+	line-height: 1.67;
+	margin: 2em 0 1em;
+}
+	h2 + h3 {
+		margin-top: -1em;
+	}
+
+h4 {
+	font-size: 1.25em;
+	line-height: 1.2;
+	margin: 1.6em 0 .8em;
+}
+	h3 + h4 {
+		margin-top: -1.2em;
+	}
+
+h5 {
+	font-size: 1em;
+	line-height: 1.5;
+	margin: 0 0 .5em;
+}
+	h4 + h5,
+	h4 + h6 {
+		margin-top: -1em;
+	}
+h6 {
+	font-size: .75em;
+	line-height: 1.33;
+	margin: 0 0 .67em;
+}
+	h5 + h6 {
+		margin-top: -.67em;
+	}
+
+abbr[title] {
+	border-bottom: 1px dotted;
+}
+
+b,
+strong {
+	font-weight: bold;
+	line-height: 22px; /*hack for mac/linux*/
+}
+
+i,
+em {
+	font-style: italic;
+}
+
+blockquote,
+pre {
+	color: #666;
+	clear: both;
+	margin: 0 0 1.5em;
+	padding: 0 1em;
+}
+
+blockquote {
+	font-style: italic;
+	border-left: 1px solid #ccc;
+}
+
+.main .intro {
+	border-bottom: 1px solid #ddd;
+	margin: 0 0 2.5em;
+	padding: 0 0 1.5em;
+
+	p {
+		color: #888;
+		font-size: 1.25em;
+		line-height: 1.6;
+		margin: 0 0 .8em;
+	}
+}
+
+.highlight {
+	background: #e9e9e9;
+	border-radius: 5px;
+	color: #888888;
+	font-family: Georgia, "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 1.5em;
+	line-height: 1.34;
+	margin: 0 0 1em;
+	padding: .67em;
+
+	p {
+		margin: 0;
+	}
+}
+
+pre {
+	white-space: pre;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
+pre,
+code {
+	font-family: Menlo, 'Ubuntu Mono', Consolas, 'Courier New', monospace;
+}
+
+p {
+	margin: 0 0 1.5em;
+}
+
+address {
+	margin: 0 0 1.5em;
+}
+
+hr {
+	border: 0;
+	border-top: 1px solid #999;
+	display: block;
+	height: 0;
+	margin: 1em auto 3em;
+	width: 75%;
+}
+
+a {
+	color: #0096d2;
+	text-decoration: none;
+
+	&:visited {
+		color: #0096d2;
+	}
+
+	&:hover,
+	&:active {
+		color: #444;
+		outline: 0;
+	}
+
+	&:focus {
+		outline: thin dotted;
+	}
+}
+
+ol,
+ul {
+	margin: 0 0 1.5em;
+	padding: 0 0 0 2em;
+}
+
+li,
+dt,
+dd {
+	margin: 0 0 .5em;
+}
+
+ul {
+	list-style: square;
+}
+
+dl {
+	margin: 0 0 1.5em;
+}
+
+dt {
+	font-weight: bold;
+	padding: 0 0 0 .5em;
+}
+
+dd {
+	padding: 0 0 0 2em;
+}
+
+mark {
+	background: #FFF6B5;
+}
+
+sup {
+	font-size: 80%;
+	vertical-align: top;
+}
+
+sub {
+	font-size: 80%;
+	vertical-align: bottom;
+}
+
+
+/* = Navigation = */
+nav {
+	ul {
+		@include grouping;
+
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		li {
+			margin: 0;
+			display: block;
+			white-space: nowrap;
+
+			a {
+				display: block;
+			}
+		}
+	}
+}
+
+
+/* == top primary navigation == */
+nav.primary {
+	> ul {
+		> li {
+			> a {
+				color: #e9e9e9;
+				padding: .25em 16px;
+			}
+			> ul {
+				margin-bottom: 1em;
+				padding-left: 1em;
+				display: none;
+				> li {
+					float: left;
+					> a {
+						font-size: .75em;
+						line-height: 1.34;
+						padding: .33em 1em .33em;
+					}
+				}
+			}
+		}
+		> li:hover {
+			> a {
+				background: #13abe8;
+				color: #e9e9e9;
+			}
+			> ul {
+				> li:hover {
+					> a {
+						color: #fff;
+					}
+				}
+			}
+		}
+		> li.active {
+			> a {
+				&,
+				&:hover {
+					background: #555;
+				}
+			}
+			> ul {
+				display: block; /* MEDIA QUERY needs to turn this to none */
+				background: #555;
+			}
+		}
+	}
+}
+
+
+header nav.secondary {
+	background: #555;
+	display: none;
+
+	ul {
+		li {
+			a {
+				color: #999;
+				font-size: .75em;
+				line-height: 2.67;
+				padding: 0 12px;
+			}
+		}
+
+		li:first-child {
+			a {
+				padding: 0 12px 0 16px;
+			}
+		}
+
+		li:hover,
+		li.active {
+			a {
+				color: #fff;
+			}
+		}
+	}
+}
+
+
+/* == aside secondary navigation == */
+aside nav.secondary {
+	> ul {
+		> li {
+			border-top: 1px solid #ddd;
+
+			> a {
+				padding: .5em 0;
+
+				&:hover {
+					color: #444;
+				}
+			}
+
+			> ul {
+				> li {
+					border: none;
+
+					> a {
+						color: #999;
+						font-size: .75em;
+						line-height: 1.34;
+						padding: .333em 0;
+					}
+				}
+
+				> li:last-child {
+					> a {
+						padding: .333em 0 1em;
+					}
+				}
+			}
+		}
+
+		> li:first-child {
+			border-top: none;
+		}
+	}
+}
+
+/* == utility navigation == */
+header nav.utility {
+	display: none;
+	position: absolute;
+	right: 0;
+	text-align: right;
+	top: 1em;
+
+	> ul {
+		position: relative;
+
+		> li {
+			float: left;
+		}
+	}
+
+	a {
+		font-size: .75em;
+		line-height: 2;
+		padding: 0 .667em;
+	}
+}
+
+
+/* = Forms = */
+button,
+input,
+select,
+textarea {
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 100%;
+
+	html.lt-ie8 & {
+		vertical-align: middle;
+	}
+}
+
+select {
+	margin: .5em 0;
+}
+
+.button,
+.checkboxes,
+.file,
+.password,
+.radios,
+.reset,
+.select,
+.submit,
+.text,
+.textarea {
+	margin-bottom: 1.5em;
+}
+
+label {
+	color: #333;
+	cursor: pointer;
+	display: block;
+	font-weight: bold;
+	line-height: 2;
+	margin: 0;
+}
+
+span.required {
+	color: #ac181b;
+}
+
+fieldset .help {
+	color: #999;
+	display: block;
+	font-size: .75em;
+	line-height: 1.34;
+	margin: 0;
+	padding: 0;
+}
+
+.radio,
+.checkbox {
+	font-weight: normal;
+	margin: 0 0 .5em;
+	padding: 0 0 0 .25em;
+}
+input[type="checkbox"],
+input[type="radio"] {
+	html.lt-ie8 & {
+		height: 13px;
+		width: 13px;
+	}
+}
+
+input[type="text"],
+input[type="password"],
+textarea {
+	border-radius: 2px;
+	border: 0;
+	box-shadow: 0 1px 4px 0 #848484 inset;
+	color: #333;
+	display: block;
+	font-size: 1em;
+	line-height: 2;
+	margin: 0;
+	padding: 0 1%;
+	width: 98%;
+
+	html.lt-ie9 & {
+		border: 1px solid #848484;
+	}
+}
+
+input[type="file"] {
+	color: #333;
+	display: block;
+	font-size: 1em;
+	line-height: 2;
+	margin: 0;
+	padding: 0;
+	width: 100%;
+}
+
+textarea {
+	height: 12em;
+	overflow: auto;
+	resize: vertical;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+	-ms-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+	-webkit-appearance: button;
+	cursor: pointer;
+
+	html.lt-ie8 & {
+		overflow: visible;
+	}
+}
+
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"],
+a.button {
+	background: #0394cd;
+	border-radius: 3px;
+	border: none;
+	color: #fff;
+	display: inline-block;
+	font-weight: bold;
+	line-height: 1;
+	margin: 0 .5em .5em 0;
+	padding: .5em .5em;
+	text-align: center;
+
+	&:hover {
+		background: #13ABE8;
+		cursor: pointer;
+	}
+
+	&:focus {
+		background: #0084B8;
+	}
+}
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+	border: 0;
+	padding: 0;
+}
+
+
+/* = Messaging = */
+.messaging {
+	border-radius: 5px;
+	margin: 0 0 1.5em;
+	padding: 1em 3.25em;
+	position: relative;
+
+	&:before {
+		background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAABFCAYAAAChbH1cAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QEQAh0Zl47LzAAAAuJJREFUWMPtmO9H3VEcx9/t5nK5ZNGMy7iJiBgxRkT2YESPNnEf7VHsUUSKnk00MSIuoz9gGqNEbItNjFhGbEYaEc0od5qItteenG87O31/nO+93x5s9eHwdb6f7+uc8zmfz+d8P0f6rwXoBHaAPeBu1vA1/sg+UMwKXOGsTGcBLgK7BnhoTANwDHQ0Cp80sM9Ai+mrmr7lRsAlM1uAp1Z/n2WevjjGlZh3M5KCjftp9dvPs0AuFRzolVTxWOBNScNpZz6bwoJTwX4kwoGKpJ4U8FZJE4lwExwzdez/aJhrujOflFQK+fi69Rzm3/lYUwIdJjiipApMW+4ZJv1RM58yM4iSvKTvpkXJkzOuCfQSLy8t3YEE3YenMzcjzSVsmO1qRQ/XbA1mMoafrAHzQM1Dd16SmoAvksoZny8/JF3TpVwcKUh6IOm5pF1JWG1H0jPzvpAGmpM0IqnmAKNazSS8vE9ufuMJddumpBtxiWm9TnDQ9iJSsuY8Pj6QdF/SeIzOR3cfypKOPeCv7GQa0/469qZTLP2xpIUEnX1JhWYD9zmQX0vaMLp3PByjtznkjIwDB8vdltSe8E1n8PDe0ySBHHjojgVn6CcPs2xYJrzqof81gC952lwe9g7krR3yHxKWGUAXPEyy6o7UJ+kk5oNxo9du3DFK70TS7bClDHsE0XaCzmicre5JOqoztzzy2Yyyyddp4f1pcnurKQJeSDp0QL98NrJe6TKrc004FCg0ZTBI0YR6j/n9XrIC7lL+0SuTbmDkPMAl6/Jh+fTHPwNwC7Dp/PivZAEuAKsOeBcoNQrOAYsOuAZ0ZzHrqgM+dmvQesETIQVWJQtw2H3XRBpAV0R/f0j5Xk0DHgpu3+wy2wSJW38uxt0SueAe4Mj2V+PHdpAEsg4UfMFtIQCArZAg2QLa0pgjD8x5lN3f6r5PBAZjavsj4Faj7lYG3oUEyWBWCSlvPCa7IAkZZOBc8vTFlt90PErGWW5fZgAAAABJRU5ErkJggg==);
+		background-position: 0 0;
+		background-repeat: no-repeat;
+		content:'';
+		display: block;
+		height: 23px;
+		left: 1em;
+		position: absolute;
+		top: 1em;
+		width: 23px;
+	}
+
+	a {
+		color: inherit;
+		text-decoration: underline;
+	}
+
+	&.error {
+		background: #C44949;
+		color: #FCFCFC;
+
+		&:before {
+			background-position: 0 0;
+		}
+	}
+
+	&.success {
+		background: #40B36E;
+		color: #FCFCFC;
+
+		&:before {
+			background-position: 0 -46px;
+		}
+	}
+
+	&.info {
+		background: #CCCCCC;
+		color: #555555;
+
+		&:before {
+			background-position: 0 -23px;
+		}
+	}
+}
+
+
+/* = Tables = */
+caption {
+	font-size: .75em;
+	line-height: 1.33em;
+}
+
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+	margin: 0 0 1.5em;
+	width: 100%;
+
+	thead {
+		th {
+			border-bottom: 1px solid #999;
+		}
+	}
+
+	td,
+	th {
+		padding: .25em .5em;
+		text-align: left;
+		vertical-align: top;
+	}
+
+	th {
+		font-weight: bold;
+	}
+}
+
+/* = Section Specific = */
+
+
+/* = Page Specific = */
+
+
+/* = Media Queries = */
+
+@include for-tablets {
+	header nav.utility {
+		display: block;
+	}
+
+	nav.primary,
+	header nav.secondary {
+		display: block;
+
+		> ul {
+			> li {
+				float: left;
+				position: relative;
+				white-space: nowrap;
+
+				> a:hover {
+					color: #ffffff;
+				}
+
+				> ul {
+					display: none;
+					left: 0;
+					overflow: hidden;
+					position: absolute;
+					width: 200px;
+					background: #13abe8;
+					margin: 0;
+					padding: 0;
+
+					> li {
+						float: none;
+						min-width: 100%;
+
+						> a {
+							padding: .6em 1.33em .6em;
+							font-size: .875em;
+							line-height: 2;
+						}
+					}
+				}
+			}
+			> li:hover {
+				> a {
+					border-top-left-radius: 6px;
+					border-top-right-radius: 6px;
+				}
+				> ul {
+					display: block;
+					z-index: 2;
+					border-bottom-left-radius: 6px;
+					border-bottom-right-radius: 6px;
+				}
+			}
+			> li.active {
+				> a {
+					border-top-left-radius: 6px;
+					border-top-right-radius: 6px;
+				}
+				> ul {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
+@include for-desktops {
+	.branding {
+		padding: 1.75em 0;
+	}
+
+	aside.primary {
+		padding: 0 1em 0 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+		width: 192px;
+	}
+
+	.main {
+		margin-right: 192px;
+		padding: 0 32px 0 0;
+	}
+
+	.mold {
+		margin: 0 auto;
+		max-width: 1024px;
+		padding: 0 16px;
+		position: relative;
+	}
+}
+
+
+/* = IE Specific = */
+
+
+/* = Print Styles = */
+@media print {
+	* {
+		background: transparent !important;
+		box-shadow: none !important;
+		color: #000 !important;
+		text-shadow: none !important;
+	}
+
+	a,
+	a:visited {
+		text-decoration: underline;
+	}
+
+	a[href]:after {
+		content: " (" attr(href) ")";
+	}
+
+	abbr[title]:after {
+		content: " (" attr(title) ")";
+	}
+
+	a[href^="javascript:"]:after,
+	a[href^="#"]:after {
+		content: '';
+	}
+
+	pre,
+	blockquote {
+		border: 1px solid #999;
+		page-break-inside: avoid;
+	}
+
+	thead {
+		display: table-header-group;
+	}
+
+	tr,
+	img {
+		page-break-inside: avoid;
+	}
+
+	@page {
+		margin: 0.5cm;
+	}
+
+	p,
+	h2,
+	h3 {
+		orphans: 3;
+		widows: 3;
+	}
+
+	h2,
+	h3 {
+		page-break-after: avoid;
+	}
+}

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -465,7 +465,6 @@ nav {
 			margin-bottom: 0;
 
 			a {
-				white-space: nowrap;
 				display: block;
 			}
 		}
@@ -516,6 +515,7 @@ header {
 				> a {
 					color: $lightgray;
 					font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+					white-space: nowrap;
 				}
 				> a:hover {
 					color: $white;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 	</head>
 	<body>
 		<header class="primary">
-			<div class="mold">
+			<div class="container">
 				<div class="branding">
 					<h1>
 						<a href="#">Boilerplate</a>
@@ -37,7 +37,6 @@
 				</div>
 				<nav class="utility">
 					<ul>
-						<li><a href="#">Home</a></li>
 						<li><a href="#">Careers</a></li>
 						<li><a href="#">Legal</a></li>
 						<li><a href="#">Log In</a></li>
@@ -45,86 +44,69 @@
 				</nav>
 			</div>
 			<nav class="primary">
-				<ul class="mold">
-					<li><a href="/">Home</a></li>
-					<li class="active">
-						<a href="#">Markup</a>
-						<ul>
-							<li>
-								<a href="#Typography">Typography</a>
-							</li>
-							<li>
-								<a href="#Articles">Articles</a>
-							</li>
-							<li>
-								<a href="#Lists">Lists</a>
-							</li>
-							<li>
-								<a href="#Tables">Tables</a>
-							</li>
-							<li>
-								<a href="#Forms">Forms</a>
-							</li>
-							<li>
-								<a href="#Breaks-and-Headings">Breaks and Headings</a>
-							</li>
-						</ul>
-					</li>
+				<ul class="container">
 					<li>
 						<a href="#">Maine</a>
-						<ul>
-							<li><a href="#">Augusta</a></li>
-							<li><a href="#">Eliot</a></li>
-							<li><a href="#">Kittery</a></li>
-							<li><a href="#">Portland</a></li>
-						</ul>
+						<div class="dropdown">
+							<ul>
+								<li><a href="#">Augusta</a></li>
+								<li><a href="#">Eliot</a></li>
+								<li><a href="#">Kittery</a></li>
+								<li><a href="#">Portland</a></li>
+							</ul>
+						</div>
+					</li>
+					<li class="active">
+						<a href="#">Markup</a>
+						<div class="dropdown">
+							<ul>
+								<li><a href="#Typography">Typography</a></li>
+								<li><a href="#Articles">Articles</a></li>
+								<li><a href="#Lists">Lists</a></li>
+								<li><a href="#Tables">Tables</a></li>
+								<li><a href="#Forms">Forms</a></li>
+								<li><a href="#Breaks-and-Headings">Breaks and Headings</a></li>
+							</ul>
+						</div>
 					</li>
 					<li>
 					    <a href="#">New Hampshire</a>
-						<ul>
-							<li><a href="#">Concord</a></li>
-							<li><a href="#">Manchester</a></li>
-							<li><a href="#">Portsmouth</a></li>
-							<li><a href="#">Hampton</a></li>
-						</ul>
+						<div class="dropdown">
+							<ul>
+								<li><a href="#">Concord</a></li>
+								<li><a href="#">Manchester</a></li>
+								<li><a href="#">Portsmouth</a></li>
+								<li><a href="#">Hampton</a></li>
+							</ul>
+						</div>
 					</li>
 					<li>
 					    <a href="#">Vermont</a>
-						<ul>
-							<li><a href="#">Montpelier</a></li>
-							<li><a href="#">Burlington</a></li>
-							<li><a href="#">Killington</a></li>
-							<li><a href="#">St. Johnsbury</a></li>
-						</ul>
+						<div class="dropdown">
+							<ul>
+								<li><a href="#">Montpelier</a></li>
+								<li><a href="#">Burlington</a></li>
+								<li><a href="#">Killington</a></li>
+								<li><a href="#">St. Johnsbury</a></li>
+							</ul>
+						</div>
 					</li>
 				</ul>
 			</nav>
 			<nav class="secondary">
-				<ul class="mold">
-					<li>
-						<a href="#Typography">Typography</a>
-					</li>
-					<li>
-						<a href="#Articles">Articles</a>
-					</li>
-					<li>
-						<a href="#Lists">Lists</a>
-					</li>
-					<li class="active">
-						<a href="#Tables">Tables</a>
-					</li>
-					<li>
-						<a href="#Forms">Forms</a>
-					</li>
-					<li>
-						<a href="#Breaks-and-Headings">Breaks and Headings</a>
-					</li>
+				<ul class="container">
+					<li><a href="#Typography">Typography</a></li>
+					<li><a href="#Articles">Articles</a></li>
+					<li><a href="#Lists">Lists</a></li>
+					<li class="active"><a href="#Tables">Tables</a></li>
+					<li><a href="#Forms">Forms</a></li>
+					<li><a href="#Breaks-and-Headings">Breaks and Headings</a></li>
 				</ul>
 			</nav>
 		</header>
 
-		<div class="torso mold">
-		<div class="main" role="main">
+		<div class="torso container">
+			<div class="main" role="main">
 				<header>
 					<h1>
 						A Simple &amp; Semantic Front-End
@@ -257,11 +239,11 @@
 						velit, ornare sit amet blandit in, mattis eget nulla.
 					</p>
 			
-				<pre>
-			Here is a block of preformatted text in the pre element.
-			
-			There is a line of whitespace between these two sentences.
-				</pre>
+<pre>
+Here is a block of preformatted text in the pre element.
+
+There is a line of whitespace between these two sentences.
+</pre>
 			
 					<p>
 						This is a filler paragraph – Ignore this. These are scattered through
@@ -521,7 +503,7 @@
 						<fieldset>
 							<h4>Radios and Checkboxes</h4>
 							<div class="radios group">
-								<h5>Choose one</h5>
+								<label>Choose one</label>
 								<label class="radio">
 									<input id="sample_form-radio" type="radio" />
 									radio
@@ -536,7 +518,7 @@
 								</label>
 							</div>
 							<div class="checkboxes group">
-								<h5>Check all that apply</h5>
+								<label>Check all that apply</label>
 								<label class="checkbox">
 									<input id="sample_form-checkbox" type="checkbox" />
 									checkbox
@@ -639,7 +621,6 @@
 
 
 					<h2 id="Headings">Headings – This is an H2</h2>
-
 					<p>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
 						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
@@ -648,7 +629,6 @@
 					</p>
 			
 					<h3>Three – This is an H3</h3>
-			
 					<p>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
 						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
@@ -657,7 +637,6 @@
 					</p>
 			
 					<h4>Four – This is an H4</h4>
-			
 					<p>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
 						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
@@ -666,7 +645,6 @@
 					</p>
 			
 					<h5>Five – This is an H5</h5>
-			
 					<p>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
 						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
@@ -675,13 +653,63 @@
 					</p>
 
 					<h6>Six – This is an H6</h6>
-
 					<p>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
 						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
 						in, mattis eget nulla. Integer tellus ligula, consectetur sed tincidunt
 						nec, tempor in enim.
 					</p>
+
+
+					<h1>Breaking Multi-Line H1 Heading – Nulla vitae elit libero, a pharetra augue. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</h1>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
+						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
+						in, mattis eget nulla. Integer tellus ligula, consectetur sed tincidunt
+						nec, tempor in enim.
+					</p>
+
+					<h2>Breaking Multi-Line H2 Heading – Nulla vitae elit libero, a pharetra augue. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</h2>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
+						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
+						in, mattis eget nulla. Integer tellus ligula, consectetur sed tincidunt
+						nec, tempor in enim.
+					</p>
+			
+					<h3>Breaking Multi-Line H3 Heading – Nulla vitae elit libero, a pharetra augue. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</h3>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
+						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
+						in, mattis eget nulla. Integer tellus ligula, consectetur sed tincidunt
+						nec, tempor in enim.
+					</p>
+			
+					<h4>Breaking Multi-Line H4 Heading – Nulla vitae elit libero, a pharetra augue. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</h4>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
+						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
+						in, mattis eget nulla. Integer tellus ligula, consectetur sed tincidunt
+						nec, tempor in enim.
+					</p>
+			
+					<h5>Breaking Multi-Line H5 Heading – Nulla vitae elit libero, a pharetra augue. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</h5>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
+						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
+						in, mattis eget nulla. Integer tellus ligula, consectetur sed tincidunt
+						nec, tempor in enim.
+					</p>
+
+					<h6>Breaking Multi-Line H6 Heading – Nulla vitae elit libero, a pharetra augue. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</h6>
+					<p>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
+						felis est, nec convallis dui. Nulla lectus velit, ornare sit amet blandit
+						in, mattis eget nulla. Integer tellus ligula, consectetur sed tincidunt
+						nec, tempor in enim.
+					</p>
+					
+					
 
 					<h1 id="Adjacent-Headings">H1 Adjacent Headings</h1>
 					<h2>H2 Lorem ipsum dolor subheading</h2>
@@ -775,7 +803,7 @@
 				</section>
 			
 				<section>
-					<h5>Browser Support</h5>
+					<h4>Browser Support</h4>
 					<p>
 						Modern Gecko and Webkit based browsers, as well as Internet Explorer 8
 						and up.
@@ -784,7 +812,7 @@
 			</aside>
 		</div>
 
-		<footer class="primary">
+		<footer class="primary container">
 			<div class="copyright">©2013 iMarc LLC.</div>
 		</footer>
 	</body>

--- a/structure.html
+++ b/structure.html
@@ -44,7 +44,7 @@
 				top: .25em;
 			}
 
-			.mold,
+			.container,
 			header.primary:after,
 			.torso:after,
 			footer.primary:after {
@@ -54,9 +54,9 @@
 			}
 
 			body:before { content: 'body'; }
-			.mold:before { content: '.mold'; }
+			.container:before { content: '.container'; }
 			header.primary:before { content: 'header.primary'; }
-			.mold.torso:before { content: '.torso.mold'; }
+			.container.torso:before { content: '.torso.container'; }
 			footer.primary:before { content: 'footer.primary'; }
 			aside.primary:before { content: 'aside.primary'; }
 
@@ -85,7 +85,7 @@
 				margin: 0 auto;
 			}
 
-			.mold {
+			.container {
 				width: 960px;
 				margin: 0 auto;
 			}
@@ -184,15 +184,15 @@
 	</head>
 	<body>
 		    <header class="primary">
-				<div class="mold">
+				<div class="container">
 					<div class="logo"></div>
 					<nav class="utility"></nav>
 				</div>
 				<nav class="primary">
-					<ul class="mold"></ul>
+					<ul class="container"></ul>
 				</nav>
 		    </header>
-			<div class="torso mold">
+			<div class="torso container">
 			    <aside class="primary">
 			        <section>
 						<span class="selector">aside.primary section</span>
@@ -240,7 +240,7 @@
 				</div>
 			</div>
 			<footer class="primary">
-				<div class="mold">
+				<div class="container">
 					<div class="copyright"></div>
 					<nav class="utility"></nav>
 				</div>


### PR DESCRIPTION
This pull request includes all the updates I've made as a result of using the current boilerplate on Handbook.

I've also forked Handbook and applied these styles - http://khamer.github.io/handbook/
#### SASS

I did this work after rewriting Boilerplate into SASS, as it felt like it would make some of this easier. I also found styling navigation in particular, to be much clearer with SASS than the CSS itself was. We don't have to continue with the SASS version, but if we like the SASS version more perhaps that is something we want to consider. I did follow very specific conventions when writing SASS, but that's a separate topic.

I've done some post-SASS formatting just to make the CSS more pleasant, but I'm sure more could happen.
#### Header Color

I switched these to dark grays, which was the direction Jeff was headed. I used two dark gray colors inspired by the colors used [here](http://windows.microsoft.com/en-us/windows-8/meet).
#### Navigation

I've changed the navigation to only change text colors with active state and removed the 'tab-like' background so that even in places where there is no secondary navigation (such as Handbook), the navigation doesn't look awkward.
#### Menus

I change the DOM structure for the dropdown menus slightly. I've introduced a `.dropdown` class, which allows for the dropdown menu to contain more than a single `ul`. This seems to match better with the sites we build. Also, it allows for crazier things, like full width (wider than `.container`) dropdowns, etc.

I **did not change** the DOM per Jeff's suggestion, as I wanted to keep the implementation for the secondary navigation and primary navigation separate, for sites that either want to implement only one or the other.
#### Fonts

I tried out some fonts and talked to Creative. I'm going to switch back to Open Sans, which is what I was using before we switched to Georgia. Open Sans is popular, clean, and very generic.

I also changed our body font-family back to `Arial, Helvetica, sans-serif`, as this is the font stack we should be using for body content, as its considered a best practice, web safe font stack.

Lastly, Creative pointed out that Handbook, being an iMarc site and iMarc branded, should be using iMarc fonts, so we should use Fjord instead of Open Sans there.
#### Polish

I did some basic polish here and there. I tweaked some colors, added a box-shadow to the dropdowns, and fixed a bug with button margins (that we accidentally introduced in the first place.)
